### PR TITLE
#38 Ride Mapper - For unit tests

### DIFF
--- a/UnitTests/Mappers/RequestMapper.cs
+++ b/UnitTests/Mappers/RequestMapper.cs
@@ -11,13 +11,14 @@ using Android.Views;
 using Android.Widget;
 
 using mRides_app.Models;
+using mRides_app.Mappers;
 
-namespace mRides_app.Mappers
+namespace UnitTests.Mappers
 {
     /**
      * This mapper class is only used for testing purposes in order to populate requests.
      * It should never be used by the activities in the app.
-     */ 
+     */
     public class RequestMapper : AbstractMapper
     {
         private RequestMapper() { }

--- a/UnitTests/Mappers/RideMapper.cs
+++ b/UnitTests/Mappers/RideMapper.cs
@@ -35,7 +35,7 @@ namespace UnitTests.Mappers
         /// <summary>
         /// Used to obtain the instance of this class, since it is a singleton.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Instance of the ride mapper</returns>
         public static RideMapper getInstance()
         {
             if (_instance == null)
@@ -49,21 +49,24 @@ namespace UnitTests.Mappers
         /// Method is used to create ride, mainly to setup the preconditions of the unit tests.
         /// </summary>
         /// <param name="ride">Ride object to be created on the server side</param>
+        /// <returns>The newly created Ride</returns>
+        public Ride CreateRide(Ride ride)
         {
+            return SendPost<Ride>(ApiEndPointUrl.createRide, ride, true);
         }
 
         /// <summary>
-        /// Method is used to add a rider to a ride, mainly to setup the preconditions of the unit tests.
+        /// Method is used to add a rider (currrent user) to a ride, mainly to setup the preconditions of the unit tests.
         /// </summary>
         /// <param name="rideId">ID of the ride to which a rider will be added</param>
-        /// <param name="userid">ID of the user to be added to the ride</param>
+        /// <returns>The ride to which the rider has been added</returns>
+        public Ride AddRiderToRide(int rideid)
         {
             object request = new
             {
-                rideid = rideid,
-                userid = userid
+                rideId = rideid
             };
-            SendPost<object>(ApiEndPointUrl.addRiderToRide, request, true);
+            return SendPost<Ride>(ApiEndPointUrl.addRiderToRide, request, true);
         }
 
         /// <summary>
@@ -71,6 +74,7 @@ namespace UnitTests.Mappers
         /// </summary>
         /// <param name="rideId">ID of the ride to be obtained</param>
         /// <returns>Ride associated with the given ID</returns>
+        public Ride GetRide(int rideId)
         {
             return SendGetWithUrlSegment<Ride>(ApiEndPointUrl.getRide, "id", rideId.ToString());
         }

--- a/UnitTests/Mappers/RideMapper.cs
+++ b/UnitTests/Mappers/RideMapper.cs
@@ -60,11 +60,12 @@ namespace UnitTests.Mappers
         /// </summary>
         /// <param name="rideId">ID of the ride to which a rider will be added</param>
         /// <returns>The ride to which the rider has been added</returns>
-        public Ride AddRiderToRide(int rideid)
+        public Ride AddRiderToRide(int rideid, int userid)
         {
             object request = new
             {
-                rideId = rideid
+                rideid = rideid,
+                userid = userid
             };
             return SendPost<Ride>(ApiEndPointUrl.addRiderToRide, request, true);
         }

--- a/UnitTests/Mappers/RideMapper.cs
+++ b/UnitTests/Mappers/RideMapper.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+
+using mRides_app.Models;
+using mRides_app.Mappers;
+
+namespace UnitTests.Mappers
+{
+    /// <summary>
+    /// The ride mapper class provides an interface for its users to perform operations on the
+    /// </summary>
+    public class RideMapper : AbstractMapper
+    {
+        private RideMapper() { }
+
+        private static RideMapper _instance;
+        public static RideMapper getInstance()
+        {
+            if (_instance == null)
+            {
+                _instance = new RideMapper();
+            }
+            return _instance;
+        }
+    }
+}

--- a/UnitTests/Mappers/RideMapper.cs
+++ b/UnitTests/Mappers/RideMapper.cs
@@ -17,12 +17,25 @@ namespace UnitTests.Mappers
 {
     /// <summary>
     /// The ride mapper class provides an interface for its users to perform operations on the
+    /// server related to Rides. This SHOULD NOT be used by the application activities.
     /// </summary>
     public class RideMapper : AbstractMapper
     {
+        
+        /// <summary>
+        /// Singleton class instance
+        /// </summary>
+        private static RideMapper _instance;
+
+        /// <summary>
+        /// Private default constructor since this class is a singleton
+        /// </summary>
         private RideMapper() { }
 
-        private static RideMapper _instance;
+        /// <summary>
+        /// Used to obtain the instance of this class, since it is a singleton.
+        /// </summary>
+        /// <returns></returns>
         public static RideMapper getInstance()
         {
             if (_instance == null)
@@ -30,6 +43,36 @@ namespace UnitTests.Mappers
                 _instance = new RideMapper();
             }
             return _instance;
+        }
+
+        /// <summary>
+        /// Method is used to create ride, mainly to setup the preconditions of the unit tests.
+        /// </summary>
+        /// <param name="ride">Ride object to be created on the server side</param>
+        {
+        }
+
+        /// <summary>
+        /// Method is used to add a rider to a ride, mainly to setup the preconditions of the unit tests.
+        /// </summary>
+        /// <param name="rideId">ID of the ride to which a rider will be added</param>
+        /// <param name="userid">ID of the user to be added to the ride</param>
+        {
+            object request = new
+            {
+                rideid = rideid,
+                userid = userid
+            };
+            SendPost<object>(ApiEndPointUrl.addRiderToRide, request, true);
+        }
+
+        /// <summary>
+        /// Method is used to obtain a ride given its ID.
+        /// </summary>
+        /// <param name="rideId">ID of the ride to be obtained</param>
+        /// <returns>Ride associated with the given ID</returns>
+        {
+            return SendGetWithUrlSegment<Ride>(ApiEndPointUrl.getRide, "id", rideId.ToString());
         }
     }
 }

--- a/UnitTests/MappersTest/ConsoleMapperTests.cs
+++ b/UnitTests/MappersTest/ConsoleMapperTests.cs
@@ -3,6 +3,7 @@ using mRides_app.Models;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using UnitTests.Mappers;
 
 namespace UnitTests
 {

--- a/UnitTests/Resources/Resource.Designer.cs
+++ b/UnitTests/Resources/Resource.Designer.cs
@@ -53,6 +53,75 @@ namespace UnitTests
 		public partial class Attribute
 		{
 			
+			// aapt resource value: 0x7f010016
+			public const int ambientEnabled = 2130771990;
+			
+			// aapt resource value: 0x7f010000
+			public const int buttonSize = 2130771968;
+			
+			// aapt resource value: 0x7f010007
+			public const int cameraBearing = 2130771975;
+			
+			// aapt resource value: 0x7f010008
+			public const int cameraTargetLat = 2130771976;
+			
+			// aapt resource value: 0x7f010009
+			public const int cameraTargetLng = 2130771977;
+			
+			// aapt resource value: 0x7f01000a
+			public const int cameraTilt = 2130771978;
+			
+			// aapt resource value: 0x7f01000b
+			public const int cameraZoom = 2130771979;
+			
+			// aapt resource value: 0x7f010005
+			public const int circleCrop = 2130771973;
+			
+			// aapt resource value: 0x7f010001
+			public const int colorScheme = 2130771969;
+			
+			// aapt resource value: 0x7f010004
+			public const int imageAspectRatio = 2130771972;
+			
+			// aapt resource value: 0x7f010003
+			public const int imageAspectRatioAdjust = 2130771971;
+			
+			// aapt resource value: 0x7f01000c
+			public const int liteMode = 2130771980;
+			
+			// aapt resource value: 0x7f010006
+			public const int mapType = 2130771974;
+			
+			// aapt resource value: 0x7f010002
+			public const int scopeUris = 2130771970;
+			
+			// aapt resource value: 0x7f01000d
+			public const int uiCompass = 2130771981;
+			
+			// aapt resource value: 0x7f010015
+			public const int uiMapToolbar = 2130771989;
+			
+			// aapt resource value: 0x7f01000e
+			public const int uiRotateGestures = 2130771982;
+			
+			// aapt resource value: 0x7f01000f
+			public const int uiScrollGestures = 2130771983;
+			
+			// aapt resource value: 0x7f010010
+			public const int uiTiltGestures = 2130771984;
+			
+			// aapt resource value: 0x7f010011
+			public const int uiZoomControls = 2130771985;
+			
+			// aapt resource value: 0x7f010012
+			public const int uiZoomGestures = 2130771986;
+			
+			// aapt resource value: 0x7f010013
+			public const int useViewLifecycle = 2130771987;
+			
+			// aapt resource value: 0x7f010014
+			public const int zOrderOnTop = 2130771988;
+			
 			static Attribute()
 			{
 				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
@@ -63,11 +132,286 @@ namespace UnitTests
 			}
 		}
 		
+		public partial class Color
+		{
+			
+			// aapt resource value: 0x7f040008
+			public const int common_action_bar_splitter = 2130968584;
+			
+			// aapt resource value: 0x7f040017
+			public const int common_google_signin_btn_text_dark = 2130968599;
+			
+			// aapt resource value: 0x7f040009
+			public const int common_google_signin_btn_text_dark_default = 2130968585;
+			
+			// aapt resource value: 0x7f04000b
+			public const int common_google_signin_btn_text_dark_disabled = 2130968587;
+			
+			// aapt resource value: 0x7f04000c
+			public const int common_google_signin_btn_text_dark_focused = 2130968588;
+			
+			// aapt resource value: 0x7f04000a
+			public const int common_google_signin_btn_text_dark_pressed = 2130968586;
+			
+			// aapt resource value: 0x7f040018
+			public const int common_google_signin_btn_text_light = 2130968600;
+			
+			// aapt resource value: 0x7f04000d
+			public const int common_google_signin_btn_text_light_default = 2130968589;
+			
+			// aapt resource value: 0x7f04000f
+			public const int common_google_signin_btn_text_light_disabled = 2130968591;
+			
+			// aapt resource value: 0x7f040010
+			public const int common_google_signin_btn_text_light_focused = 2130968592;
+			
+			// aapt resource value: 0x7f04000e
+			public const int common_google_signin_btn_text_light_pressed = 2130968590;
+			
+			// aapt resource value: 0x7f040019
+			public const int common_plus_signin_btn_text_dark = 2130968601;
+			
+			// aapt resource value: 0x7f040000
+			public const int common_plus_signin_btn_text_dark_default = 2130968576;
+			
+			// aapt resource value: 0x7f040002
+			public const int common_plus_signin_btn_text_dark_disabled = 2130968578;
+			
+			// aapt resource value: 0x7f040003
+			public const int common_plus_signin_btn_text_dark_focused = 2130968579;
+			
+			// aapt resource value: 0x7f040001
+			public const int common_plus_signin_btn_text_dark_pressed = 2130968577;
+			
+			// aapt resource value: 0x7f04001a
+			public const int common_plus_signin_btn_text_light = 2130968602;
+			
+			// aapt resource value: 0x7f040004
+			public const int common_plus_signin_btn_text_light_default = 2130968580;
+			
+			// aapt resource value: 0x7f040006
+			public const int common_plus_signin_btn_text_light_disabled = 2130968582;
+			
+			// aapt resource value: 0x7f040007
+			public const int common_plus_signin_btn_text_light_focused = 2130968583;
+			
+			// aapt resource value: 0x7f040005
+			public const int common_plus_signin_btn_text_light_pressed = 2130968581;
+			
+			// aapt resource value: 0x7f040013
+			public const int place_autocomplete_prediction_primary_text = 2130968595;
+			
+			// aapt resource value: 0x7f040014
+			public const int place_autocomplete_prediction_primary_text_highlight = 2130968596;
+			
+			// aapt resource value: 0x7f040015
+			public const int place_autocomplete_prediction_secondary_text = 2130968597;
+			
+			// aapt resource value: 0x7f040012
+			public const int place_autocomplete_search_hint = 2130968594;
+			
+			// aapt resource value: 0x7f040011
+			public const int place_autocomplete_search_text = 2130968593;
+			
+			// aapt resource value: 0x7f040016
+			public const int place_autocomplete_separator = 2130968598;
+			
+			static Color()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Color()
+			{
+			}
+		}
+		
+		public partial class Dimension
+		{
+			
+			// aapt resource value: 0x7f070000
+			public const int place_autocomplete_button_padding = 2131165184;
+			
+			// aapt resource value: 0x7f070008
+			public const int place_autocomplete_powered_by_google_height = 2131165192;
+			
+			// aapt resource value: 0x7f070009
+			public const int place_autocomplete_powered_by_google_start = 2131165193;
+			
+			// aapt resource value: 0x7f070003
+			public const int place_autocomplete_prediction_height = 2131165187;
+			
+			// aapt resource value: 0x7f070004
+			public const int place_autocomplete_prediction_horizontal_margin = 2131165188;
+			
+			// aapt resource value: 0x7f070005
+			public const int place_autocomplete_prediction_primary_text = 2131165189;
+			
+			// aapt resource value: 0x7f070006
+			public const int place_autocomplete_prediction_secondary_text = 2131165190;
+			
+			// aapt resource value: 0x7f070002
+			public const int place_autocomplete_progress_horizontal_margin = 2131165186;
+			
+			// aapt resource value: 0x7f070001
+			public const int place_autocomplete_progress_size = 2131165185;
+			
+			// aapt resource value: 0x7f070007
+			public const int place_autocomplete_separator_start = 2131165191;
+			
+			static Dimension()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Dimension()
+			{
+			}
+		}
+		
 		public partial class Drawable
 		{
 			
 			// aapt resource value: 0x7f020000
-			public const int Icon = 2130837504;
+			public const int common_full_open_on_phone = 2130837504;
+			
+			// aapt resource value: 0x7f020001
+			public const int common_google_signin_btn_icon_dark = 2130837505;
+			
+			// aapt resource value: 0x7f020002
+			public const int common_google_signin_btn_icon_dark_disabled = 2130837506;
+			
+			// aapt resource value: 0x7f020003
+			public const int common_google_signin_btn_icon_dark_focused = 2130837507;
+			
+			// aapt resource value: 0x7f020004
+			public const int common_google_signin_btn_icon_dark_normal = 2130837508;
+			
+			// aapt resource value: 0x7f020005
+			public const int common_google_signin_btn_icon_dark_pressed = 2130837509;
+			
+			// aapt resource value: 0x7f020006
+			public const int common_google_signin_btn_icon_light = 2130837510;
+			
+			// aapt resource value: 0x7f020007
+			public const int common_google_signin_btn_icon_light_disabled = 2130837511;
+			
+			// aapt resource value: 0x7f020008
+			public const int common_google_signin_btn_icon_light_focused = 2130837512;
+			
+			// aapt resource value: 0x7f020009
+			public const int common_google_signin_btn_icon_light_normal = 2130837513;
+			
+			// aapt resource value: 0x7f02000a
+			public const int common_google_signin_btn_icon_light_pressed = 2130837514;
+			
+			// aapt resource value: 0x7f02000b
+			public const int common_google_signin_btn_text_dark = 2130837515;
+			
+			// aapt resource value: 0x7f02000c
+			public const int common_google_signin_btn_text_dark_disabled = 2130837516;
+			
+			// aapt resource value: 0x7f02000d
+			public const int common_google_signin_btn_text_dark_focused = 2130837517;
+			
+			// aapt resource value: 0x7f02000e
+			public const int common_google_signin_btn_text_dark_normal = 2130837518;
+			
+			// aapt resource value: 0x7f02000f
+			public const int common_google_signin_btn_text_dark_pressed = 2130837519;
+			
+			// aapt resource value: 0x7f020010
+			public const int common_google_signin_btn_text_light = 2130837520;
+			
+			// aapt resource value: 0x7f020011
+			public const int common_google_signin_btn_text_light_disabled = 2130837521;
+			
+			// aapt resource value: 0x7f020012
+			public const int common_google_signin_btn_text_light_focused = 2130837522;
+			
+			// aapt resource value: 0x7f020013
+			public const int common_google_signin_btn_text_light_normal = 2130837523;
+			
+			// aapt resource value: 0x7f020014
+			public const int common_google_signin_btn_text_light_pressed = 2130837524;
+			
+			// aapt resource value: 0x7f020015
+			public const int common_ic_googleplayservices = 2130837525;
+			
+			// aapt resource value: 0x7f020016
+			public const int common_plus_signin_btn_icon_dark = 2130837526;
+			
+			// aapt resource value: 0x7f020017
+			public const int common_plus_signin_btn_icon_dark_disabled = 2130837527;
+			
+			// aapt resource value: 0x7f020018
+			public const int common_plus_signin_btn_icon_dark_focused = 2130837528;
+			
+			// aapt resource value: 0x7f020019
+			public const int common_plus_signin_btn_icon_dark_normal = 2130837529;
+			
+			// aapt resource value: 0x7f02001a
+			public const int common_plus_signin_btn_icon_dark_pressed = 2130837530;
+			
+			// aapt resource value: 0x7f02001b
+			public const int common_plus_signin_btn_icon_light = 2130837531;
+			
+			// aapt resource value: 0x7f02001c
+			public const int common_plus_signin_btn_icon_light_disabled = 2130837532;
+			
+			// aapt resource value: 0x7f02001d
+			public const int common_plus_signin_btn_icon_light_focused = 2130837533;
+			
+			// aapt resource value: 0x7f02001e
+			public const int common_plus_signin_btn_icon_light_normal = 2130837534;
+			
+			// aapt resource value: 0x7f02001f
+			public const int common_plus_signin_btn_icon_light_pressed = 2130837535;
+			
+			// aapt resource value: 0x7f020020
+			public const int common_plus_signin_btn_text_dark = 2130837536;
+			
+			// aapt resource value: 0x7f020021
+			public const int common_plus_signin_btn_text_dark_disabled = 2130837537;
+			
+			// aapt resource value: 0x7f020022
+			public const int common_plus_signin_btn_text_dark_focused = 2130837538;
+			
+			// aapt resource value: 0x7f020023
+			public const int common_plus_signin_btn_text_dark_normal = 2130837539;
+			
+			// aapt resource value: 0x7f020024
+			public const int common_plus_signin_btn_text_dark_pressed = 2130837540;
+			
+			// aapt resource value: 0x7f020025
+			public const int common_plus_signin_btn_text_light = 2130837541;
+			
+			// aapt resource value: 0x7f020026
+			public const int common_plus_signin_btn_text_light_disabled = 2130837542;
+			
+			// aapt resource value: 0x7f020027
+			public const int common_plus_signin_btn_text_light_focused = 2130837543;
+			
+			// aapt resource value: 0x7f020028
+			public const int common_plus_signin_btn_text_light_normal = 2130837544;
+			
+			// aapt resource value: 0x7f020029
+			public const int common_plus_signin_btn_text_light_pressed = 2130837545;
+			
+			// aapt resource value: 0x7f02002a
+			public const int Icon = 2130837546;
+			
+			// aapt resource value: 0x7f02002b
+			public const int places_ic_clear = 2130837547;
+			
+			// aapt resource value: 0x7f02002c
+			public const int places_ic_search = 2130837548;
+			
+			// aapt resource value: 0x7f02002d
+			public const int powered_by_google_dark = 2130837549;
+			
+			// aapt resource value: 0x7f02002e
+			public const int powered_by_google_light = 2130837550;
 			
 			static Drawable()
 			{
@@ -82,59 +426,122 @@ namespace UnitTests
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f050001
-			public const int OptionHostName = 2131034113;
+			// aapt resource value: 0x7f08000e
+			public const int OptionHostName = 2131230734;
 			
-			// aapt resource value: 0x7f050002
-			public const int OptionPort = 2131034114;
+			// aapt resource value: 0x7f08000f
+			public const int OptionPort = 2131230735;
 			
-			// aapt resource value: 0x7f050000
-			public const int OptionRemoteServer = 2131034112;
+			// aapt resource value: 0x7f08000d
+			public const int OptionRemoteServer = 2131230733;
 			
-			// aapt resource value: 0x7f050010
-			public const int OptionsButton = 2131034128;
+			// aapt resource value: 0x7f080025
+			public const int OptionsButton = 2131230757;
 			
-			// aapt resource value: 0x7f05000b
-			public const int ResultFullName = 2131034123;
+			// aapt resource value: 0x7f080020
+			public const int ResultFullName = 2131230752;
 			
-			// aapt resource value: 0x7f05000d
-			public const int ResultMessage = 2131034125;
+			// aapt resource value: 0x7f080022
+			public const int ResultMessage = 2131230754;
 			
-			// aapt resource value: 0x7f05000c
-			public const int ResultResultState = 2131034124;
+			// aapt resource value: 0x7f080021
+			public const int ResultResultState = 2131230753;
 			
-			// aapt resource value: 0x7f05000a
-			public const int ResultRunSingleMethodTest = 2131034122;
+			// aapt resource value: 0x7f08001f
+			public const int ResultRunSingleMethodTest = 2131230751;
 			
-			// aapt resource value: 0x7f05000e
-			public const int ResultStackTrace = 2131034126;
+			// aapt resource value: 0x7f080023
+			public const int ResultStackTrace = 2131230755;
 			
-			// aapt resource value: 0x7f050006
-			public const int ResultsFailed = 2131034118;
+			// aapt resource value: 0x7f08001b
+			public const int ResultsFailed = 2131230747;
 			
-			// aapt resource value: 0x7f050003
-			public const int ResultsId = 2131034115;
+			// aapt resource value: 0x7f080018
+			public const int ResultsId = 2131230744;
 			
-			// aapt resource value: 0x7f050007
-			public const int ResultsIgnored = 2131034119;
+			// aapt resource value: 0x7f08001c
+			public const int ResultsIgnored = 2131230748;
 			
-			// aapt resource value: 0x7f050008
-			public const int ResultsInconclusive = 2131034120;
+			// aapt resource value: 0x7f08001d
+			public const int ResultsInconclusive = 2131230749;
 			
-			// aapt resource value: 0x7f050009
-			public const int ResultsMessage = 2131034121;
+			// aapt resource value: 0x7f08001e
+			public const int ResultsMessage = 2131230750;
 			
-			// aapt resource value: 0x7f050005
-			public const int ResultsPassed = 2131034117;
+			// aapt resource value: 0x7f08001a
+			public const int ResultsPassed = 2131230746;
 			
-			// aapt resource value: 0x7f050004
-			public const int ResultsResult = 2131034116;
+			// aapt resource value: 0x7f080019
+			public const int ResultsResult = 2131230745;
 			
-			// aapt resource value: 0x7f05000f
-			public const int RunTestsButton = 2131034127;
+			// aapt resource value: 0x7f080024
+			public const int RunTestsButton = 2131230756;
 			
-			// aapt resource value: 0x7f050011
-			public const int TestSuiteListView = 2131034129;
+			// aapt resource value: 0x7f080026
+			public const int TestSuiteListView = 2131230758;
+			
+			// aapt resource value: 0x7f080006
+			public const int adjust_height = 2131230726;
+			
+			// aapt resource value: 0x7f080007
+			public const int adjust_width = 2131230727;
+			
+			// aapt resource value: 0x7f080003
+			public const int auto = 2131230723;
+			
+			// aapt resource value: 0x7f080004
+			public const int dark = 2131230724;
+			
+			// aapt resource value: 0x7f080009
+			public const int hybrid = 2131230729;
+			
+			// aapt resource value: 0x7f080000
+			public const int icon_only = 2131230720;
+			
+			// aapt resource value: 0x7f080005
+			public const int light = 2131230725;
+			
+			// aapt resource value: 0x7f080008
+			public const int none = 2131230728;
+			
+			// aapt resource value: 0x7f08000a
+			public const int normal = 2131230730;
+			
+			// aapt resource value: 0x7f080012
+			public const int place_autocomplete_clear_button = 2131230738;
+			
+			// aapt resource value: 0x7f080014
+			public const int place_autocomplete_powered_by_google = 2131230740;
+			
+			// aapt resource value: 0x7f080016
+			public const int place_autocomplete_prediction_primary_text = 2131230742;
+			
+			// aapt resource value: 0x7f080017
+			public const int place_autocomplete_prediction_secondary_text = 2131230743;
+			
+			// aapt resource value: 0x7f080015
+			public const int place_autocomplete_progress = 2131230741;
+			
+			// aapt resource value: 0x7f080010
+			public const int place_autocomplete_search_button = 2131230736;
+			
+			// aapt resource value: 0x7f080011
+			public const int place_autocomplete_search_input = 2131230737;
+			
+			// aapt resource value: 0x7f080013
+			public const int place_autocomplete_separator = 2131230739;
+			
+			// aapt resource value: 0x7f08000b
+			public const int satellite = 2131230731;
+			
+			// aapt resource value: 0x7f080001
+			public const int standard = 2131230721;
+			
+			// aapt resource value: 0x7f08000c
+			public const int terrain = 2131230732;
+			
+			// aapt resource value: 0x7f080002
+			public const int wide = 2131230722;
 			
 			static Id()
 			{
@@ -146,6 +553,22 @@ namespace UnitTests
 			}
 		}
 		
+		public partial class Integer
+		{
+			
+			// aapt resource value: 0x7f060000
+			public const int google_play_services_version = 2131099648;
+			
+			static Integer()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Integer()
+			{
+			}
+		}
+		
 		public partial class Layout
 		{
 			
@@ -153,13 +576,25 @@ namespace UnitTests
 			public const int options = 2130903040;
 			
 			// aapt resource value: 0x7f030001
-			public const int results = 2130903041;
+			public const int place_autocomplete_fragment = 2130903041;
 			
 			// aapt resource value: 0x7f030002
-			public const int test_result = 2130903042;
+			public const int place_autocomplete_item_powered_by_google = 2130903042;
 			
 			// aapt resource value: 0x7f030003
-			public const int test_suite = 2130903043;
+			public const int place_autocomplete_item_prediction = 2130903043;
+			
+			// aapt resource value: 0x7f030004
+			public const int place_autocomplete_progress = 2130903044;
+			
+			// aapt resource value: 0x7f030005
+			public const int results = 2130903045;
+			
+			// aapt resource value: 0x7f030006
+			public const int test_result = 2130903046;
+			
+			// aapt resource value: 0x7f030007
+			public const int test_suite = 2130903047;
 			
 			static Layout()
 			{
@@ -174,11 +609,110 @@ namespace UnitTests
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f040001
-			public const int ApplicationName = 2130968577;
+			// aapt resource value: 0x7f050022
+			public const int ApplicationName = 2131034146;
 			
-			// aapt resource value: 0x7f040000
-			public const int Hello = 2130968576;
+			// aapt resource value: 0x7f050021
+			public const int Hello = 2131034145;
+			
+			// aapt resource value: 0x7f05001d
+			public const int auth_google_play_services_client_facebook_display_name = 2131034141;
+			
+			// aapt resource value: 0x7f05001c
+			public const int auth_google_play_services_client_google_display_name = 2131034140;
+			
+			// aapt resource value: 0x7f050015
+			public const int common_google_play_services_api_unavailable_text = 2131034133;
+			
+			// aapt resource value: 0x7f050007
+			public const int common_google_play_services_enable_button = 2131034119;
+			
+			// aapt resource value: 0x7f050006
+			public const int common_google_play_services_enable_text = 2131034118;
+			
+			// aapt resource value: 0x7f050005
+			public const int common_google_play_services_enable_title = 2131034117;
+			
+			// aapt resource value: 0x7f050004
+			public const int common_google_play_services_install_button = 2131034116;
+			
+			// aapt resource value: 0x7f050002
+			public const int common_google_play_services_install_text_phone = 2131034114;
+			
+			// aapt resource value: 0x7f050003
+			public const int common_google_play_services_install_text_tablet = 2131034115;
+			
+			// aapt resource value: 0x7f050001
+			public const int common_google_play_services_install_title = 2131034113;
+			
+			// aapt resource value: 0x7f050010
+			public const int common_google_play_services_invalid_account_text = 2131034128;
+			
+			// aapt resource value: 0x7f05000f
+			public const int common_google_play_services_invalid_account_title = 2131034127;
+			
+			// aapt resource value: 0x7f05000e
+			public const int common_google_play_services_network_error_text = 2131034126;
+			
+			// aapt resource value: 0x7f05000d
+			public const int common_google_play_services_network_error_title = 2131034125;
+			
+			// aapt resource value: 0x7f050000
+			public const int common_google_play_services_notification_ticker = 2131034112;
+			
+			// aapt resource value: 0x7f050019
+			public const int common_google_play_services_restricted_profile_text = 2131034137;
+			
+			// aapt resource value: 0x7f050018
+			public const int common_google_play_services_restricted_profile_title = 2131034136;
+			
+			// aapt resource value: 0x7f050017
+			public const int common_google_play_services_sign_in_failed_text = 2131034135;
+			
+			// aapt resource value: 0x7f050016
+			public const int common_google_play_services_sign_in_failed_title = 2131034134;
+			
+			// aapt resource value: 0x7f05001e
+			public const int common_google_play_services_unknown_issue = 2131034142;
+			
+			// aapt resource value: 0x7f050012
+			public const int common_google_play_services_unsupported_text = 2131034130;
+			
+			// aapt resource value: 0x7f050011
+			public const int common_google_play_services_unsupported_title = 2131034129;
+			
+			// aapt resource value: 0x7f050013
+			public const int common_google_play_services_update_button = 2131034131;
+			
+			// aapt resource value: 0x7f050009
+			public const int common_google_play_services_update_text = 2131034121;
+			
+			// aapt resource value: 0x7f050008
+			public const int common_google_play_services_update_title = 2131034120;
+			
+			// aapt resource value: 0x7f05000c
+			public const int common_google_play_services_updating_text = 2131034124;
+			
+			// aapt resource value: 0x7f05000b
+			public const int common_google_play_services_updating_title = 2131034123;
+			
+			// aapt resource value: 0x7f05000a
+			public const int common_google_play_services_wear_update_text = 2131034122;
+			
+			// aapt resource value: 0x7f050014
+			public const int common_open_on_phone = 2131034132;
+			
+			// aapt resource value: 0x7f05001a
+			public const int common_signin_button_text = 2131034138;
+			
+			// aapt resource value: 0x7f05001b
+			public const int common_signin_button_text_long = 2131034139;
+			
+			// aapt resource value: 0x7f050020
+			public const int place_autocomplete_clear_button = 2131034144;
+			
+			// aapt resource value: 0x7f05001f
+			public const int place_autocomplete_search_hint = 2131034143;
 			
 			static String()
 			{
@@ -186,6 +720,117 @@ namespace UnitTests
 			}
 			
 			private String()
+			{
+			}
+		}
+		
+		public partial class Styleable
+		{
+			
+			public static int[] LoadingImageView = new int[] {
+					2130771971,
+					2130771972,
+					2130771973};
+			
+			// aapt resource value: 2
+			public const int LoadingImageView_circleCrop = 2;
+			
+			// aapt resource value: 1
+			public const int LoadingImageView_imageAspectRatio = 1;
+			
+			// aapt resource value: 0
+			public const int LoadingImageView_imageAspectRatioAdjust = 0;
+			
+			public static int[] MapAttrs = new int[] {
+					2130771974,
+					2130771975,
+					2130771976,
+					2130771977,
+					2130771978,
+					2130771979,
+					2130771980,
+					2130771981,
+					2130771982,
+					2130771983,
+					2130771984,
+					2130771985,
+					2130771986,
+					2130771987,
+					2130771988,
+					2130771989,
+					2130771990};
+			
+			// aapt resource value: 16
+			public const int MapAttrs_ambientEnabled = 16;
+			
+			// aapt resource value: 1
+			public const int MapAttrs_cameraBearing = 1;
+			
+			// aapt resource value: 2
+			public const int MapAttrs_cameraTargetLat = 2;
+			
+			// aapt resource value: 3
+			public const int MapAttrs_cameraTargetLng = 3;
+			
+			// aapt resource value: 4
+			public const int MapAttrs_cameraTilt = 4;
+			
+			// aapt resource value: 5
+			public const int MapAttrs_cameraZoom = 5;
+			
+			// aapt resource value: 6
+			public const int MapAttrs_liteMode = 6;
+			
+			// aapt resource value: 0
+			public const int MapAttrs_mapType = 0;
+			
+			// aapt resource value: 7
+			public const int MapAttrs_uiCompass = 7;
+			
+			// aapt resource value: 15
+			public const int MapAttrs_uiMapToolbar = 15;
+			
+			// aapt resource value: 8
+			public const int MapAttrs_uiRotateGestures = 8;
+			
+			// aapt resource value: 9
+			public const int MapAttrs_uiScrollGestures = 9;
+			
+			// aapt resource value: 10
+			public const int MapAttrs_uiTiltGestures = 10;
+			
+			// aapt resource value: 11
+			public const int MapAttrs_uiZoomControls = 11;
+			
+			// aapt resource value: 12
+			public const int MapAttrs_uiZoomGestures = 12;
+			
+			// aapt resource value: 13
+			public const int MapAttrs_useViewLifecycle = 13;
+			
+			// aapt resource value: 14
+			public const int MapAttrs_zOrderOnTop = 14;
+			
+			public static int[] SignInButton = new int[] {
+					2130771968,
+					2130771969,
+					2130771970};
+			
+			// aapt resource value: 0
+			public const int SignInButton_buttonSize = 0;
+			
+			// aapt resource value: 1
+			public const int SignInButton_colorScheme = 1;
+			
+			// aapt resource value: 2
+			public const int SignInButton_scopeUris = 2;
+			
+			static Styleable()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Styleable()
 			{
 			}
 		}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -58,6 +58,8 @@
     <Compile Include="MappersTest\ConsoleMapperTests.cs" />
     <Compile Include="MappersTest\RequestMapperTests.cs" />
     <Compile Include="MappersTest\UserMapperTests.cs" />
+    <Compile Include="Mappers\RequestMapper.cs" />
+    <Compile Include="Mappers\RideMapper.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/UnitTests/UnitTests.csproj.bak
+++ b/UnitTests/UnitTests.csproj.bak
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/mRides-app/Mappers/AbstractMapper.cs
+++ b/mRides-app/Mappers/AbstractMapper.cs
@@ -207,5 +207,9 @@ namespace mRides_app.Mappers
         public const string getReviews = "User/getReviews/{id}";
         public const string leaveReview = "User/leaveReview";
 
+        // Ride related url
+        public const string createRide = "Ride/createRide";
+        public const string addRiderToRide = "Ride/addRiderToRide";
+        public const string getRide = "Ride/getRide/{id}";
     }
 }

--- a/mRides-app/Mappers/AbstractMapper.cs
+++ b/mRides-app/Mappers/AbstractMapper.cs
@@ -188,7 +188,7 @@ namespace mRides_app.Mappers
     // AVAILABLE URLS
     // ---------------------------------------------------------------------------
 
-    class ApiEndPointUrl
+    public class ApiEndPointUrl
     {
         // Console related url
         public const string findDrivers = "Console/findDrivers";

--- a/mRides-app/Models/Ride.cs
+++ b/mRides-app/Models/Ride.cs
@@ -19,7 +19,7 @@ namespace mRides_app.Models
         public string location { get; set; }
         public DateTime dateTime { get; set; }
         public Boolean isWeekly { get; set; }
-
+        public string type;
 
         //1 Driver per Ride
         public int? DriverID { get; set; }

--- a/mRides-app/mRides-app.csproj
+++ b/mRides-app/mRides-app.csproj
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -119,7 +119,6 @@
     <Compile Include="Mappers\MRidesJSON\FindRidersJson.cs" />
     <Compile Include="Mappers\AbstractMapper.cs" />
     <Compile Include="Mappers\ConsoleMapper.cs" />
-    <Compile Include="Mappers\RequestMapper.cs" />
     <Compile Include="Mappers\UserMapper.cs" />
     <Compile Include="PreferencesActivity.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />

--- a/mRides-app/mRides-app.csproj.bak
+++ b/mRides-app/mRides-app.csproj.bak
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>


### PR DESCRIPTION
- Added Ride Mapper to the unit test project
- Moved Request Mapper to the unit test project
- Added missing attribute "type" in Ride model
- Changed visibility of inner class holding the API end URLs to be public so that the test project has access to it

Those changes are required for the leave feedback integration test to function, since we need to be able to create mock rides to test that.