### PR TITLE
#28 Null check for list of reviews obtained from server added

### DIFF
--- a/mRides-app/Gateways/UserGateway.cs
+++ b/mRides-app/Gateways/UserGateway.cs
@@ -125,10 +125,13 @@ namespace mRides_app.Gateways
 
             // Build the list of feedbacks to be returns
             List<Models.Feedback> feedbacks = new List<Models.Feedback>();
-            foreach (dynamic oFeedback in oFeedbacks)
+            if(oFeedbacks != null)
             {
-                Models.Feedback feedback = JsonConvert.DeserializeObject<Models.Feedback>(oFeedback.ToString());
-                feedbacks.Add(feedback);
+                foreach (dynamic oFeedback in oFeedbacks)
+                {
+                    Models.Feedback feedback = JsonConvert.DeserializeObject<Models.Feedback>(oFeedback.ToString());
+                    feedbacks.Add(feedback);
+                }
             }
 
             return feedbacks;


### PR DESCRIPTION
#28 
For any reasons, if the server is either updating, or is down, the list
of feedback obtained may be null caused by an internal server error, or
any other reasons. The app side should robust enough to not crash
whenever that happens. A null check is added to the list before looping
through it