### PR TITLE
Bug#99/Mulitple Match Rider + Wrong activity when match is finished

### DIFF
--- a/UnitTests/Resources/Resource.Designer.cs
+++ b/UnitTests/Resources/Resource.Designer.cs
@@ -50,8 +50,813 @@ namespace UnitTests
 			global::Xamarin.Android.NUnitLite.Resource.Layout.test_suite = global::UnitTests.Resource.Layout.test_suite;
 		}
 		
+		public partial class Animation
+		{
+			
+			// aapt resource value: 0x7f040000
+			public const int abc_fade_in = 2130968576;
+			
+			// aapt resource value: 0x7f040001
+			public const int abc_fade_out = 2130968577;
+			
+			// aapt resource value: 0x7f040002
+			public const int abc_grow_fade_in_from_bottom = 2130968578;
+			
+			// aapt resource value: 0x7f040003
+			public const int abc_popup_enter = 2130968579;
+			
+			// aapt resource value: 0x7f040004
+			public const int abc_popup_exit = 2130968580;
+			
+			// aapt resource value: 0x7f040005
+			public const int abc_shrink_fade_out_from_bottom = 2130968581;
+			
+			// aapt resource value: 0x7f040006
+			public const int abc_slide_in_bottom = 2130968582;
+			
+			// aapt resource value: 0x7f040007
+			public const int abc_slide_in_top = 2130968583;
+			
+			// aapt resource value: 0x7f040008
+			public const int abc_slide_out_bottom = 2130968584;
+			
+			// aapt resource value: 0x7f040009
+			public const int abc_slide_out_top = 2130968585;
+			
+			static Animation()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Animation()
+			{
+			}
+		}
+		
 		public partial class Attribute
 		{
+			
+			// aapt resource value: 0x7f01005d
+			public const int actionBarDivider = 2130772061;
+			
+			// aapt resource value: 0x7f01005e
+			public const int actionBarItemBackground = 2130772062;
+			
+			// aapt resource value: 0x7f010057
+			public const int actionBarPopupTheme = 2130772055;
+			
+			// aapt resource value: 0x7f01005c
+			public const int actionBarSize = 2130772060;
+			
+			// aapt resource value: 0x7f010059
+			public const int actionBarSplitStyle = 2130772057;
+			
+			// aapt resource value: 0x7f010058
+			public const int actionBarStyle = 2130772056;
+			
+			// aapt resource value: 0x7f010053
+			public const int actionBarTabBarStyle = 2130772051;
+			
+			// aapt resource value: 0x7f010052
+			public const int actionBarTabStyle = 2130772050;
+			
+			// aapt resource value: 0x7f010054
+			public const int actionBarTabTextStyle = 2130772052;
+			
+			// aapt resource value: 0x7f01005a
+			public const int actionBarTheme = 2130772058;
+			
+			// aapt resource value: 0x7f01005b
+			public const int actionBarWidgetTheme = 2130772059;
+			
+			// aapt resource value: 0x7f010078
+			public const int actionButtonStyle = 2130772088;
+			
+			// aapt resource value: 0x7f010074
+			public const int actionDropDownStyle = 2130772084;
+			
+			// aapt resource value: 0x7f0100c9
+			public const int actionLayout = 2130772169;
+			
+			// aapt resource value: 0x7f01005f
+			public const int actionMenuTextAppearance = 2130772063;
+			
+			// aapt resource value: 0x7f010060
+			public const int actionMenuTextColor = 2130772064;
+			
+			// aapt resource value: 0x7f010063
+			public const int actionModeBackground = 2130772067;
+			
+			// aapt resource value: 0x7f010062
+			public const int actionModeCloseButtonStyle = 2130772066;
+			
+			// aapt resource value: 0x7f010065
+			public const int actionModeCloseDrawable = 2130772069;
+			
+			// aapt resource value: 0x7f010067
+			public const int actionModeCopyDrawable = 2130772071;
+			
+			// aapt resource value: 0x7f010066
+			public const int actionModeCutDrawable = 2130772070;
+			
+			// aapt resource value: 0x7f01006b
+			public const int actionModeFindDrawable = 2130772075;
+			
+			// aapt resource value: 0x7f010068
+			public const int actionModePasteDrawable = 2130772072;
+			
+			// aapt resource value: 0x7f01006d
+			public const int actionModePopupWindowStyle = 2130772077;
+			
+			// aapt resource value: 0x7f010069
+			public const int actionModeSelectAllDrawable = 2130772073;
+			
+			// aapt resource value: 0x7f01006a
+			public const int actionModeShareDrawable = 2130772074;
+			
+			// aapt resource value: 0x7f010064
+			public const int actionModeSplitBackground = 2130772068;
+			
+			// aapt resource value: 0x7f010061
+			public const int actionModeStyle = 2130772065;
+			
+			// aapt resource value: 0x7f01006c
+			public const int actionModeWebSearchDrawable = 2130772076;
+			
+			// aapt resource value: 0x7f010055
+			public const int actionOverflowButtonStyle = 2130772053;
+			
+			// aapt resource value: 0x7f010056
+			public const int actionOverflowMenuStyle = 2130772054;
+			
+			// aapt resource value: 0x7f0100cb
+			public const int actionProviderClass = 2130772171;
+			
+			// aapt resource value: 0x7f0100ca
+			public const int actionViewClass = 2130772170;
+			
+			// aapt resource value: 0x7f010080
+			public const int activityChooserViewStyle = 2130772096;
+			
+			// aapt resource value: 0x7f0100a4
+			public const int alertDialogButtonGroupStyle = 2130772132;
+			
+			// aapt resource value: 0x7f0100a5
+			public const int alertDialogCenterButtons = 2130772133;
+			
+			// aapt resource value: 0x7f0100a3
+			public const int alertDialogStyle = 2130772131;
+			
+			// aapt resource value: 0x7f0100a6
+			public const int alertDialogTheme = 2130772134;
+			
+			// aapt resource value: 0x7f0100b9
+			public const int allowStacking = 2130772153;
+			
+			// aapt resource value: 0x7f0100ba
+			public const int alpha = 2130772154;
+			
+			// aapt resource value: 0x7f010016
+			public const int ambientEnabled = 2130771990;
+			
+			// aapt resource value: 0x7f0100c1
+			public const int arrowHeadLength = 2130772161;
+			
+			// aapt resource value: 0x7f0100c2
+			public const int arrowShaftLength = 2130772162;
+			
+			// aapt resource value: 0x7f0100ab
+			public const int autoCompleteTextViewStyle = 2130772139;
+			
+			// aapt resource value: 0x7f010029
+			public const int background = 2130772009;
+			
+			// aapt resource value: 0x7f01002b
+			public const int backgroundSplit = 2130772011;
+			
+			// aapt resource value: 0x7f01002a
+			public const int backgroundStacked = 2130772010;
+			
+			// aapt resource value: 0x7f0100fc
+			public const int backgroundTint = 2130772220;
+			
+			// aapt resource value: 0x7f0100fd
+			public const int backgroundTintMode = 2130772221;
+			
+			// aapt resource value: 0x7f0100c3
+			public const int barLength = 2130772163;
+			
+			// aapt resource value: 0x7f01007d
+			public const int borderlessButtonStyle = 2130772093;
+			
+			// aapt resource value: 0x7f01007a
+			public const int buttonBarButtonStyle = 2130772090;
+			
+			// aapt resource value: 0x7f0100a9
+			public const int buttonBarNegativeButtonStyle = 2130772137;
+			
+			// aapt resource value: 0x7f0100aa
+			public const int buttonBarNeutralButtonStyle = 2130772138;
+			
+			// aapt resource value: 0x7f0100a8
+			public const int buttonBarPositiveButtonStyle = 2130772136;
+			
+			// aapt resource value: 0x7f010079
+			public const int buttonBarStyle = 2130772089;
+			
+			// aapt resource value: 0x7f0100f1
+			public const int buttonGravity = 2130772209;
+			
+			// aapt resource value: 0x7f01003e
+			public const int buttonPanelSideLayout = 2130772030;
+			
+			// aapt resource value: 0x7f010003
+			public const int buttonSize = 2130771971;
+			
+			// aapt resource value: 0x7f0100ac
+			public const int buttonStyle = 2130772140;
+			
+			// aapt resource value: 0x7f0100ad
+			public const int buttonStyleSmall = 2130772141;
+			
+			// aapt resource value: 0x7f0100bb
+			public const int buttonTint = 2130772155;
+			
+			// aapt resource value: 0x7f0100bc
+			public const int buttonTintMode = 2130772156;
+			
+			// aapt resource value: 0x7f010007
+			public const int cameraBearing = 2130771975;
+			
+			// aapt resource value: 0x7f010018
+			public const int cameraMaxZoomPreference = 2130771992;
+			
+			// aapt resource value: 0x7f010017
+			public const int cameraMinZoomPreference = 2130771991;
+			
+			// aapt resource value: 0x7f010008
+			public const int cameraTargetLat = 2130771976;
+			
+			// aapt resource value: 0x7f010009
+			public const int cameraTargetLng = 2130771977;
+			
+			// aapt resource value: 0x7f01000a
+			public const int cameraTilt = 2130771978;
+			
+			// aapt resource value: 0x7f01000b
+			public const int cameraZoom = 2130771979;
+			
+			// aapt resource value: 0x7f0100ae
+			public const int checkboxStyle = 2130772142;
+			
+			// aapt resource value: 0x7f0100af
+			public const int checkedTextViewStyle = 2130772143;
+			
+			// aapt resource value: 0x7f010002
+			public const int circleCrop = 2130771970;
+			
+			// aapt resource value: 0x7f0100d4
+			public const int closeIcon = 2130772180;
+			
+			// aapt resource value: 0x7f01003b
+			public const int closeItemLayout = 2130772027;
+			
+			// aapt resource value: 0x7f0100f3
+			public const int collapseContentDescription = 2130772211;
+			
+			// aapt resource value: 0x7f0100f2
+			public const int collapseIcon = 2130772210;
+			
+			// aapt resource value: 0x7f0100bd
+			public const int color = 2130772157;
+			
+			// aapt resource value: 0x7f01009b
+			public const int colorAccent = 2130772123;
+			
+			// aapt resource value: 0x7f0100a2
+			public const int colorBackgroundFloating = 2130772130;
+			
+			// aapt resource value: 0x7f01009f
+			public const int colorButtonNormal = 2130772127;
+			
+			// aapt resource value: 0x7f01009d
+			public const int colorControlActivated = 2130772125;
+			
+			// aapt resource value: 0x7f01009e
+			public const int colorControlHighlight = 2130772126;
+			
+			// aapt resource value: 0x7f01009c
+			public const int colorControlNormal = 2130772124;
+			
+			// aapt resource value: 0x7f010099
+			public const int colorPrimary = 2130772121;
+			
+			// aapt resource value: 0x7f01009a
+			public const int colorPrimaryDark = 2130772122;
+			
+			// aapt resource value: 0x7f010004
+			public const int colorScheme = 2130771972;
+			
+			// aapt resource value: 0x7f0100a0
+			public const int colorSwitchThumbNormal = 2130772128;
+			
+			// aapt resource value: 0x7f0100d9
+			public const int commitIcon = 2130772185;
+			
+			// aapt resource value: 0x7f010034
+			public const int contentInsetEnd = 2130772020;
+			
+			// aapt resource value: 0x7f010038
+			public const int contentInsetEndWithActions = 2130772024;
+			
+			// aapt resource value: 0x7f010035
+			public const int contentInsetLeft = 2130772021;
+			
+			// aapt resource value: 0x7f010036
+			public const int contentInsetRight = 2130772022;
+			
+			// aapt resource value: 0x7f010033
+			public const int contentInsetStart = 2130772019;
+			
+			// aapt resource value: 0x7f010037
+			public const int contentInsetStartWithNavigation = 2130772023;
+			
+			// aapt resource value: 0x7f0100a1
+			public const int controlBackground = 2130772129;
+			
+			// aapt resource value: 0x7f01002c
+			public const int customNavigationLayout = 2130772012;
+			
+			// aapt resource value: 0x7f0100d3
+			public const int defaultQueryHint = 2130772179;
+			
+			// aapt resource value: 0x7f010072
+			public const int dialogPreferredPadding = 2130772082;
+			
+			// aapt resource value: 0x7f010071
+			public const int dialogTheme = 2130772081;
+			
+			// aapt resource value: 0x7f010022
+			public const int displayOptions = 2130772002;
+			
+			// aapt resource value: 0x7f010028
+			public const int divider = 2130772008;
+			
+			// aapt resource value: 0x7f01007f
+			public const int dividerHorizontal = 2130772095;
+			
+			// aapt resource value: 0x7f0100c7
+			public const int dividerPadding = 2130772167;
+			
+			// aapt resource value: 0x7f01007e
+			public const int dividerVertical = 2130772094;
+			
+			// aapt resource value: 0x7f0100bf
+			public const int drawableSize = 2130772159;
+			
+			// aapt resource value: 0x7f01001d
+			public const int drawerArrowStyle = 2130771997;
+			
+			// aapt resource value: 0x7f010091
+			public const int dropDownListViewStyle = 2130772113;
+			
+			// aapt resource value: 0x7f010075
+			public const int dropdownListPreferredItemHeight = 2130772085;
+			
+			// aapt resource value: 0x7f010086
+			public const int editTextBackground = 2130772102;
+			
+			// aapt resource value: 0x7f010085
+			public const int editTextColor = 2130772101;
+			
+			// aapt resource value: 0x7f0100b0
+			public const int editTextStyle = 2130772144;
+			
+			// aapt resource value: 0x7f010039
+			public const int elevation = 2130772025;
+			
+			// aapt resource value: 0x7f01003d
+			public const int expandActivityOverflowButtonDrawable = 2130772029;
+			
+			// aapt resource value: 0x7f0100c0
+			public const int gapBetweenBars = 2130772160;
+			
+			// aapt resource value: 0x7f0100d5
+			public const int goIcon = 2130772181;
+			
+			// aapt resource value: 0x7f01001e
+			public const int height = 2130771998;
+			
+			// aapt resource value: 0x7f010032
+			public const int hideOnContentScroll = 2130772018;
+			
+			// aapt resource value: 0x7f010077
+			public const int homeAsUpIndicator = 2130772087;
+			
+			// aapt resource value: 0x7f01002d
+			public const int homeLayout = 2130772013;
+			
+			// aapt resource value: 0x7f010026
+			public const int icon = 2130772006;
+			
+			// aapt resource value: 0x7f0100d1
+			public const int iconifiedByDefault = 2130772177;
+			
+			// aapt resource value: 0x7f010001
+			public const int imageAspectRatio = 2130771969;
+			
+			// aapt resource value: 0x7f010000
+			public const int imageAspectRatioAdjust = 2130771968;
+			
+			// aapt resource value: 0x7f010087
+			public const int imageButtonStyle = 2130772103;
+			
+			// aapt resource value: 0x7f01002f
+			public const int indeterminateProgressStyle = 2130772015;
+			
+			// aapt resource value: 0x7f01003c
+			public const int initialActivityCount = 2130772028;
+			
+			// aapt resource value: 0x7f01001f
+			public const int isLightTheme = 2130771999;
+			
+			// aapt resource value: 0x7f010031
+			public const int itemPadding = 2130772017;
+			
+			// aapt resource value: 0x7f01001b
+			public const int latLngBoundsNorthEastLatitude = 2130771995;
+			
+			// aapt resource value: 0x7f01001c
+			public const int latLngBoundsNorthEastLongitude = 2130771996;
+			
+			// aapt resource value: 0x7f010019
+			public const int latLngBoundsSouthWestLatitude = 2130771993;
+			
+			// aapt resource value: 0x7f01001a
+			public const int latLngBoundsSouthWestLongitude = 2130771994;
+			
+			// aapt resource value: 0x7f0100d0
+			public const int layout = 2130772176;
+			
+			// aapt resource value: 0x7f010098
+			public const int listChoiceBackgroundIndicator = 2130772120;
+			
+			// aapt resource value: 0x7f010073
+			public const int listDividerAlertDialog = 2130772083;
+			
+			// aapt resource value: 0x7f010042
+			public const int listItemLayout = 2130772034;
+			
+			// aapt resource value: 0x7f01003f
+			public const int listLayout = 2130772031;
+			
+			// aapt resource value: 0x7f0100b8
+			public const int listMenuViewStyle = 2130772152;
+			
+			// aapt resource value: 0x7f010092
+			public const int listPopupWindowStyle = 2130772114;
+			
+			// aapt resource value: 0x7f01008c
+			public const int listPreferredItemHeight = 2130772108;
+			
+			// aapt resource value: 0x7f01008e
+			public const int listPreferredItemHeightLarge = 2130772110;
+			
+			// aapt resource value: 0x7f01008d
+			public const int listPreferredItemHeightSmall = 2130772109;
+			
+			// aapt resource value: 0x7f01008f
+			public const int listPreferredItemPaddingLeft = 2130772111;
+			
+			// aapt resource value: 0x7f010090
+			public const int listPreferredItemPaddingRight = 2130772112;
+			
+			// aapt resource value: 0x7f01000c
+			public const int liteMode = 2130771980;
+			
+			// aapt resource value: 0x7f010027
+			public const int logo = 2130772007;
+			
+			// aapt resource value: 0x7f0100f6
+			public const int logoDescription = 2130772214;
+			
+			// aapt resource value: 0x7f010006
+			public const int mapType = 2130771974;
+			
+			// aapt resource value: 0x7f0100f0
+			public const int maxButtonHeight = 2130772208;
+			
+			// aapt resource value: 0x7f0100c5
+			public const int measureWithLargestChild = 2130772165;
+			
+			// aapt resource value: 0x7f010040
+			public const int multiChoiceItemLayout = 2130772032;
+			
+			// aapt resource value: 0x7f0100f5
+			public const int navigationContentDescription = 2130772213;
+			
+			// aapt resource value: 0x7f0100f4
+			public const int navigationIcon = 2130772212;
+			
+			// aapt resource value: 0x7f010021
+			public const int navigationMode = 2130772001;
+			
+			// aapt resource value: 0x7f0100ce
+			public const int overlapAnchor = 2130772174;
+			
+			// aapt resource value: 0x7f0100fa
+			public const int paddingEnd = 2130772218;
+			
+			// aapt resource value: 0x7f0100f9
+			public const int paddingStart = 2130772217;
+			
+			// aapt resource value: 0x7f010095
+			public const int panelBackground = 2130772117;
+			
+			// aapt resource value: 0x7f010097
+			public const int panelMenuListTheme = 2130772119;
+			
+			// aapt resource value: 0x7f010096
+			public const int panelMenuListWidth = 2130772118;
+			
+			// aapt resource value: 0x7f010083
+			public const int popupMenuStyle = 2130772099;
+			
+			// aapt resource value: 0x7f01003a
+			public const int popupTheme = 2130772026;
+			
+			// aapt resource value: 0x7f010084
+			public const int popupWindowStyle = 2130772100;
+			
+			// aapt resource value: 0x7f0100cc
+			public const int preserveIconSpacing = 2130772172;
+			
+			// aapt resource value: 0x7f010030
+			public const int progressBarPadding = 2130772016;
+			
+			// aapt resource value: 0x7f01002e
+			public const int progressBarStyle = 2130772014;
+			
+			// aapt resource value: 0x7f0100db
+			public const int queryBackground = 2130772187;
+			
+			// aapt resource value: 0x7f0100d2
+			public const int queryHint = 2130772178;
+			
+			// aapt resource value: 0x7f0100b1
+			public const int radioButtonStyle = 2130772145;
+			
+			// aapt resource value: 0x7f0100b2
+			public const int ratingBarStyle = 2130772146;
+			
+			// aapt resource value: 0x7f0100b3
+			public const int ratingBarStyleIndicator = 2130772147;
+			
+			// aapt resource value: 0x7f0100b4
+			public const int ratingBarStyleSmall = 2130772148;
+			
+			// aapt resource value: 0x7f010005
+			public const int scopeUris = 2130771973;
+			
+			// aapt resource value: 0x7f0100d7
+			public const int searchHintIcon = 2130772183;
+			
+			// aapt resource value: 0x7f0100d6
+			public const int searchIcon = 2130772182;
+			
+			// aapt resource value: 0x7f01008b
+			public const int searchViewStyle = 2130772107;
+			
+			// aapt resource value: 0x7f0100b5
+			public const int seekBarStyle = 2130772149;
+			
+			// aapt resource value: 0x7f01007b
+			public const int selectableItemBackground = 2130772091;
+			
+			// aapt resource value: 0x7f01007c
+			public const int selectableItemBackgroundBorderless = 2130772092;
+			
+			// aapt resource value: 0x7f0100c8
+			public const int showAsAction = 2130772168;
+			
+			// aapt resource value: 0x7f0100c6
+			public const int showDividers = 2130772166;
+			
+			// aapt resource value: 0x7f0100e7
+			public const int showText = 2130772199;
+			
+			// aapt resource value: 0x7f010041
+			public const int singleChoiceItemLayout = 2130772033;
+			
+			// aapt resource value: 0x7f0100be
+			public const int spinBars = 2130772158;
+			
+			// aapt resource value: 0x7f010076
+			public const int spinnerDropDownItemStyle = 2130772086;
+			
+			// aapt resource value: 0x7f0100b6
+			public const int spinnerStyle = 2130772150;
+			
+			// aapt resource value: 0x7f0100e6
+			public const int splitTrack = 2130772198;
+			
+			// aapt resource value: 0x7f010043
+			public const int srcCompat = 2130772035;
+			
+			// aapt resource value: 0x7f0100cf
+			public const int state_above_anchor = 2130772175;
+			
+			// aapt resource value: 0x7f0100cd
+			public const int subMenuArrow = 2130772173;
+			
+			// aapt resource value: 0x7f0100dc
+			public const int submitBackground = 2130772188;
+			
+			// aapt resource value: 0x7f010023
+			public const int subtitle = 2130772003;
+			
+			// aapt resource value: 0x7f0100e9
+			public const int subtitleTextAppearance = 2130772201;
+			
+			// aapt resource value: 0x7f0100f8
+			public const int subtitleTextColor = 2130772216;
+			
+			// aapt resource value: 0x7f010025
+			public const int subtitleTextStyle = 2130772005;
+			
+			// aapt resource value: 0x7f0100da
+			public const int suggestionRowLayout = 2130772186;
+			
+			// aapt resource value: 0x7f0100e4
+			public const int switchMinWidth = 2130772196;
+			
+			// aapt resource value: 0x7f0100e5
+			public const int switchPadding = 2130772197;
+			
+			// aapt resource value: 0x7f0100b7
+			public const int switchStyle = 2130772151;
+			
+			// aapt resource value: 0x7f0100e3
+			public const int switchTextAppearance = 2130772195;
+			
+			// aapt resource value: 0x7f010047
+			public const int textAllCaps = 2130772039;
+			
+			// aapt resource value: 0x7f01006e
+			public const int textAppearanceLargePopupMenu = 2130772078;
+			
+			// aapt resource value: 0x7f010093
+			public const int textAppearanceListItem = 2130772115;
+			
+			// aapt resource value: 0x7f010094
+			public const int textAppearanceListItemSmall = 2130772116;
+			
+			// aapt resource value: 0x7f010070
+			public const int textAppearancePopupMenuHeader = 2130772080;
+			
+			// aapt resource value: 0x7f010089
+			public const int textAppearanceSearchResultSubtitle = 2130772105;
+			
+			// aapt resource value: 0x7f010088
+			public const int textAppearanceSearchResultTitle = 2130772104;
+			
+			// aapt resource value: 0x7f01006f
+			public const int textAppearanceSmallPopupMenu = 2130772079;
+			
+			// aapt resource value: 0x7f0100a7
+			public const int textColorAlertDialogListItem = 2130772135;
+			
+			// aapt resource value: 0x7f01008a
+			public const int textColorSearchUrl = 2130772106;
+			
+			// aapt resource value: 0x7f0100fb
+			public const int theme = 2130772219;
+			
+			// aapt resource value: 0x7f0100c4
+			public const int thickness = 2130772164;
+			
+			// aapt resource value: 0x7f0100e2
+			public const int thumbTextPadding = 2130772194;
+			
+			// aapt resource value: 0x7f0100dd
+			public const int thumbTint = 2130772189;
+			
+			// aapt resource value: 0x7f0100de
+			public const int thumbTintMode = 2130772190;
+			
+			// aapt resource value: 0x7f010044
+			public const int tickMark = 2130772036;
+			
+			// aapt resource value: 0x7f010045
+			public const int tickMarkTint = 2130772037;
+			
+			// aapt resource value: 0x7f010046
+			public const int tickMarkTintMode = 2130772038;
+			
+			// aapt resource value: 0x7f010020
+			public const int title = 2130772000;
+			
+			// aapt resource value: 0x7f0100ea
+			public const int titleMargin = 2130772202;
+			
+			// aapt resource value: 0x7f0100ee
+			public const int titleMarginBottom = 2130772206;
+			
+			// aapt resource value: 0x7f0100ec
+			public const int titleMarginEnd = 2130772204;
+			
+			// aapt resource value: 0x7f0100eb
+			public const int titleMarginStart = 2130772203;
+			
+			// aapt resource value: 0x7f0100ed
+			public const int titleMarginTop = 2130772205;
+			
+			// aapt resource value: 0x7f0100ef
+			public const int titleMargins = 2130772207;
+			
+			// aapt resource value: 0x7f0100e8
+			public const int titleTextAppearance = 2130772200;
+			
+			// aapt resource value: 0x7f0100f7
+			public const int titleTextColor = 2130772215;
+			
+			// aapt resource value: 0x7f010024
+			public const int titleTextStyle = 2130772004;
+			
+			// aapt resource value: 0x7f010082
+			public const int toolbarNavigationButtonStyle = 2130772098;
+			
+			// aapt resource value: 0x7f010081
+			public const int toolbarStyle = 2130772097;
+			
+			// aapt resource value: 0x7f0100df
+			public const int track = 2130772191;
+			
+			// aapt resource value: 0x7f0100e0
+			public const int trackTint = 2130772192;
+			
+			// aapt resource value: 0x7f0100e1
+			public const int trackTintMode = 2130772193;
+			
+			// aapt resource value: 0x7f01000d
+			public const int uiCompass = 2130771981;
+			
+			// aapt resource value: 0x7f010015
+			public const int uiMapToolbar = 2130771989;
+			
+			// aapt resource value: 0x7f01000e
+			public const int uiRotateGestures = 2130771982;
+			
+			// aapt resource value: 0x7f01000f
+			public const int uiScrollGestures = 2130771983;
+			
+			// aapt resource value: 0x7f010010
+			public const int uiTiltGestures = 2130771984;
+			
+			// aapt resource value: 0x7f010011
+			public const int uiZoomControls = 2130771985;
+			
+			// aapt resource value: 0x7f010012
+			public const int uiZoomGestures = 2130771986;
+			
+			// aapt resource value: 0x7f010013
+			public const int useViewLifecycle = 2130771987;
+			
+			// aapt resource value: 0x7f0100d8
+			public const int voiceIcon = 2130772184;
+			
+			// aapt resource value: 0x7f010048
+			public const int windowActionBar = 2130772040;
+			
+			// aapt resource value: 0x7f01004a
+			public const int windowActionBarOverlay = 2130772042;
+			
+			// aapt resource value: 0x7f01004b
+			public const int windowActionModeOverlay = 2130772043;
+			
+			// aapt resource value: 0x7f01004f
+			public const int windowFixedHeightMajor = 2130772047;
+			
+			// aapt resource value: 0x7f01004d
+			public const int windowFixedHeightMinor = 2130772045;
+			
+			// aapt resource value: 0x7f01004c
+			public const int windowFixedWidthMajor = 2130772044;
+			
+			// aapt resource value: 0x7f01004e
+			public const int windowFixedWidthMinor = 2130772046;
+			
+			// aapt resource value: 0x7f010050
+			public const int windowMinWidthMajor = 2130772048;
+			
+			// aapt resource value: 0x7f010051
+			public const int windowMinWidthMinor = 2130772049;
+			
+			// aapt resource value: 0x7f010049
+			public const int windowNoTitle = 2130772041;
+			
+			// aapt resource value: 0x7f010014
+			public const int zOrderOnTop = 2130771988;
 			
 			static Attribute()
 			{
@@ -63,11 +868,947 @@ namespace UnitTests
 			}
 		}
 		
+		public partial class Boolean
+		{
+			
+			// aapt resource value: 0x7f0a0000
+			public const int abc_action_bar_embed_tabs = 2131361792;
+			
+			// aapt resource value: 0x7f0a0001
+			public const int abc_allow_stacked_button_bar = 2131361793;
+			
+			// aapt resource value: 0x7f0a0002
+			public const int abc_config_actionMenuItemAllCaps = 2131361794;
+			
+			// aapt resource value: 0x7f0a0003
+			public const int abc_config_closeDialogWhenTouchOutside = 2131361795;
+			
+			// aapt resource value: 0x7f0a0004
+			public const int abc_config_showMenuShortcutsWhenKeyboardPresent = 2131361796;
+			
+			static Boolean()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Boolean()
+			{
+			}
+		}
+		
+		public partial class Color
+		{
+			
+			// aapt resource value: 0x7f070048
+			public const int abc_background_cache_hint_selector_material_dark = 2131165256;
+			
+			// aapt resource value: 0x7f070049
+			public const int abc_background_cache_hint_selector_material_light = 2131165257;
+			
+			// aapt resource value: 0x7f07004a
+			public const int abc_btn_colored_borderless_text_material = 2131165258;
+			
+			// aapt resource value: 0x7f07004b
+			public const int abc_color_highlight_material = 2131165259;
+			
+			// aapt resource value: 0x7f07000e
+			public const int abc_input_method_navigation_guard = 2131165198;
+			
+			// aapt resource value: 0x7f07004c
+			public const int abc_primary_text_disable_only_material_dark = 2131165260;
+			
+			// aapt resource value: 0x7f07004d
+			public const int abc_primary_text_disable_only_material_light = 2131165261;
+			
+			// aapt resource value: 0x7f07004e
+			public const int abc_primary_text_material_dark = 2131165262;
+			
+			// aapt resource value: 0x7f07004f
+			public const int abc_primary_text_material_light = 2131165263;
+			
+			// aapt resource value: 0x7f070050
+			public const int abc_search_url_text = 2131165264;
+			
+			// aapt resource value: 0x7f07000f
+			public const int abc_search_url_text_normal = 2131165199;
+			
+			// aapt resource value: 0x7f070010
+			public const int abc_search_url_text_pressed = 2131165200;
+			
+			// aapt resource value: 0x7f070011
+			public const int abc_search_url_text_selected = 2131165201;
+			
+			// aapt resource value: 0x7f070051
+			public const int abc_secondary_text_material_dark = 2131165265;
+			
+			// aapt resource value: 0x7f070052
+			public const int abc_secondary_text_material_light = 2131165266;
+			
+			// aapt resource value: 0x7f070053
+			public const int abc_tint_btn_checkable = 2131165267;
+			
+			// aapt resource value: 0x7f070054
+			public const int abc_tint_default = 2131165268;
+			
+			// aapt resource value: 0x7f070055
+			public const int abc_tint_edittext = 2131165269;
+			
+			// aapt resource value: 0x7f070056
+			public const int abc_tint_seek_thumb = 2131165270;
+			
+			// aapt resource value: 0x7f070057
+			public const int abc_tint_spinner = 2131165271;
+			
+			// aapt resource value: 0x7f070058
+			public const int abc_tint_switch_thumb = 2131165272;
+			
+			// aapt resource value: 0x7f070059
+			public const int abc_tint_switch_track = 2131165273;
+			
+			// aapt resource value: 0x7f070012
+			public const int accent_material_dark = 2131165202;
+			
+			// aapt resource value: 0x7f070013
+			public const int accent_material_light = 2131165203;
+			
+			// aapt resource value: 0x7f070014
+			public const int background_floating_material_dark = 2131165204;
+			
+			// aapt resource value: 0x7f070015
+			public const int background_floating_material_light = 2131165205;
+			
+			// aapt resource value: 0x7f070016
+			public const int background_material_dark = 2131165206;
+			
+			// aapt resource value: 0x7f070017
+			public const int background_material_light = 2131165207;
+			
+			// aapt resource value: 0x7f070018
+			public const int bright_foreground_disabled_material_dark = 2131165208;
+			
+			// aapt resource value: 0x7f070019
+			public const int bright_foreground_disabled_material_light = 2131165209;
+			
+			// aapt resource value: 0x7f07001a
+			public const int bright_foreground_inverse_material_dark = 2131165210;
+			
+			// aapt resource value: 0x7f07001b
+			public const int bright_foreground_inverse_material_light = 2131165211;
+			
+			// aapt resource value: 0x7f07001c
+			public const int bright_foreground_material_dark = 2131165212;
+			
+			// aapt resource value: 0x7f07001d
+			public const int bright_foreground_material_light = 2131165213;
+			
+			// aapt resource value: 0x7f07001e
+			public const int button_material_dark = 2131165214;
+			
+			// aapt resource value: 0x7f07001f
+			public const int button_material_light = 2131165215;
+			
+			// aapt resource value: 0x7f07005a
+			public const int common_google_signin_btn_text_dark = 2131165274;
+			
+			// aapt resource value: 0x7f070006
+			public const int common_google_signin_btn_text_dark_default = 2131165190;
+			
+			// aapt resource value: 0x7f070007
+			public const int common_google_signin_btn_text_dark_disabled = 2131165191;
+			
+			// aapt resource value: 0x7f070008
+			public const int common_google_signin_btn_text_dark_focused = 2131165192;
+			
+			// aapt resource value: 0x7f070009
+			public const int common_google_signin_btn_text_dark_pressed = 2131165193;
+			
+			// aapt resource value: 0x7f07005b
+			public const int common_google_signin_btn_text_light = 2131165275;
+			
+			// aapt resource value: 0x7f07000a
+			public const int common_google_signin_btn_text_light_default = 2131165194;
+			
+			// aapt resource value: 0x7f07000b
+			public const int common_google_signin_btn_text_light_disabled = 2131165195;
+			
+			// aapt resource value: 0x7f07000c
+			public const int common_google_signin_btn_text_light_focused = 2131165196;
+			
+			// aapt resource value: 0x7f07000d
+			public const int common_google_signin_btn_text_light_pressed = 2131165197;
+			
+			// aapt resource value: 0x7f070020
+			public const int dim_foreground_disabled_material_dark = 2131165216;
+			
+			// aapt resource value: 0x7f070021
+			public const int dim_foreground_disabled_material_light = 2131165217;
+			
+			// aapt resource value: 0x7f070022
+			public const int dim_foreground_material_dark = 2131165218;
+			
+			// aapt resource value: 0x7f070023
+			public const int dim_foreground_material_light = 2131165219;
+			
+			// aapt resource value: 0x7f070024
+			public const int foreground_material_dark = 2131165220;
+			
+			// aapt resource value: 0x7f070025
+			public const int foreground_material_light = 2131165221;
+			
+			// aapt resource value: 0x7f070026
+			public const int highlighted_text_material_dark = 2131165222;
+			
+			// aapt resource value: 0x7f070027
+			public const int highlighted_text_material_light = 2131165223;
+			
+			// aapt resource value: 0x7f070028
+			public const int hint_foreground_material_dark = 2131165224;
+			
+			// aapt resource value: 0x7f070029
+			public const int hint_foreground_material_light = 2131165225;
+			
+			// aapt resource value: 0x7f07002a
+			public const int material_blue_grey_800 = 2131165226;
+			
+			// aapt resource value: 0x7f07002b
+			public const int material_blue_grey_900 = 2131165227;
+			
+			// aapt resource value: 0x7f07002c
+			public const int material_blue_grey_950 = 2131165228;
+			
+			// aapt resource value: 0x7f07002d
+			public const int material_deep_teal_200 = 2131165229;
+			
+			// aapt resource value: 0x7f07002e
+			public const int material_deep_teal_500 = 2131165230;
+			
+			// aapt resource value: 0x7f07002f
+			public const int material_grey_100 = 2131165231;
+			
+			// aapt resource value: 0x7f070030
+			public const int material_grey_300 = 2131165232;
+			
+			// aapt resource value: 0x7f070031
+			public const int material_grey_50 = 2131165233;
+			
+			// aapt resource value: 0x7f070032
+			public const int material_grey_600 = 2131165234;
+			
+			// aapt resource value: 0x7f070033
+			public const int material_grey_800 = 2131165235;
+			
+			// aapt resource value: 0x7f070034
+			public const int material_grey_850 = 2131165236;
+			
+			// aapt resource value: 0x7f070035
+			public const int material_grey_900 = 2131165237;
+			
+			// aapt resource value: 0x7f070000
+			public const int place_autocomplete_prediction_primary_text = 2131165184;
+			
+			// aapt resource value: 0x7f070001
+			public const int place_autocomplete_prediction_primary_text_highlight = 2131165185;
+			
+			// aapt resource value: 0x7f070002
+			public const int place_autocomplete_prediction_secondary_text = 2131165186;
+			
+			// aapt resource value: 0x7f070003
+			public const int place_autocomplete_search_hint = 2131165187;
+			
+			// aapt resource value: 0x7f070004
+			public const int place_autocomplete_search_text = 2131165188;
+			
+			// aapt resource value: 0x7f070005
+			public const int place_autocomplete_separator = 2131165189;
+			
+			// aapt resource value: 0x7f070036
+			public const int primary_dark_material_dark = 2131165238;
+			
+			// aapt resource value: 0x7f070037
+			public const int primary_dark_material_light = 2131165239;
+			
+			// aapt resource value: 0x7f070038
+			public const int primary_material_dark = 2131165240;
+			
+			// aapt resource value: 0x7f070039
+			public const int primary_material_light = 2131165241;
+			
+			// aapt resource value: 0x7f07003a
+			public const int primary_text_default_material_dark = 2131165242;
+			
+			// aapt resource value: 0x7f07003b
+			public const int primary_text_default_material_light = 2131165243;
+			
+			// aapt resource value: 0x7f07003c
+			public const int primary_text_disabled_material_dark = 2131165244;
+			
+			// aapt resource value: 0x7f07003d
+			public const int primary_text_disabled_material_light = 2131165245;
+			
+			// aapt resource value: 0x7f07003e
+			public const int ripple_material_dark = 2131165246;
+			
+			// aapt resource value: 0x7f07003f
+			public const int ripple_material_light = 2131165247;
+			
+			// aapt resource value: 0x7f070040
+			public const int secondary_text_default_material_dark = 2131165248;
+			
+			// aapt resource value: 0x7f070041
+			public const int secondary_text_default_material_light = 2131165249;
+			
+			// aapt resource value: 0x7f070042
+			public const int secondary_text_disabled_material_dark = 2131165250;
+			
+			// aapt resource value: 0x7f070043
+			public const int secondary_text_disabled_material_light = 2131165251;
+			
+			// aapt resource value: 0x7f070044
+			public const int switch_thumb_disabled_material_dark = 2131165252;
+			
+			// aapt resource value: 0x7f070045
+			public const int switch_thumb_disabled_material_light = 2131165253;
+			
+			// aapt resource value: 0x7f07005c
+			public const int switch_thumb_material_dark = 2131165276;
+			
+			// aapt resource value: 0x7f07005d
+			public const int switch_thumb_material_light = 2131165277;
+			
+			// aapt resource value: 0x7f070046
+			public const int switch_thumb_normal_material_dark = 2131165254;
+			
+			// aapt resource value: 0x7f070047
+			public const int switch_thumb_normal_material_light = 2131165255;
+			
+			static Color()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Color()
+			{
+			}
+		}
+		
+		public partial class Dimension
+		{
+			
+			// aapt resource value: 0x7f080016
+			public const int abc_action_bar_content_inset_material = 2131230742;
+			
+			// aapt resource value: 0x7f080017
+			public const int abc_action_bar_content_inset_with_nav = 2131230743;
+			
+			// aapt resource value: 0x7f08000b
+			public const int abc_action_bar_default_height_material = 2131230731;
+			
+			// aapt resource value: 0x7f080018
+			public const int abc_action_bar_default_padding_end_material = 2131230744;
+			
+			// aapt resource value: 0x7f080019
+			public const int abc_action_bar_default_padding_start_material = 2131230745;
+			
+			// aapt resource value: 0x7f08001b
+			public const int abc_action_bar_elevation_material = 2131230747;
+			
+			// aapt resource value: 0x7f08001c
+			public const int abc_action_bar_icon_vertical_padding_material = 2131230748;
+			
+			// aapt resource value: 0x7f08001d
+			public const int abc_action_bar_overflow_padding_end_material = 2131230749;
+			
+			// aapt resource value: 0x7f08001e
+			public const int abc_action_bar_overflow_padding_start_material = 2131230750;
+			
+			// aapt resource value: 0x7f08000c
+			public const int abc_action_bar_progress_bar_size = 2131230732;
+			
+			// aapt resource value: 0x7f08001f
+			public const int abc_action_bar_stacked_max_height = 2131230751;
+			
+			// aapt resource value: 0x7f080020
+			public const int abc_action_bar_stacked_tab_max_width = 2131230752;
+			
+			// aapt resource value: 0x7f080021
+			public const int abc_action_bar_subtitle_bottom_margin_material = 2131230753;
+			
+			// aapt resource value: 0x7f080022
+			public const int abc_action_bar_subtitle_top_margin_material = 2131230754;
+			
+			// aapt resource value: 0x7f080023
+			public const int abc_action_button_min_height_material = 2131230755;
+			
+			// aapt resource value: 0x7f080024
+			public const int abc_action_button_min_width_material = 2131230756;
+			
+			// aapt resource value: 0x7f080025
+			public const int abc_action_button_min_width_overflow_material = 2131230757;
+			
+			// aapt resource value: 0x7f08000a
+			public const int abc_alert_dialog_button_bar_height = 2131230730;
+			
+			// aapt resource value: 0x7f080026
+			public const int abc_button_inset_horizontal_material = 2131230758;
+			
+			// aapt resource value: 0x7f080027
+			public const int abc_button_inset_vertical_material = 2131230759;
+			
+			// aapt resource value: 0x7f080028
+			public const int abc_button_padding_horizontal_material = 2131230760;
+			
+			// aapt resource value: 0x7f080029
+			public const int abc_button_padding_vertical_material = 2131230761;
+			
+			// aapt resource value: 0x7f08002a
+			public const int abc_cascading_menus_min_smallest_width = 2131230762;
+			
+			// aapt resource value: 0x7f08000f
+			public const int abc_config_prefDialogWidth = 2131230735;
+			
+			// aapt resource value: 0x7f08002b
+			public const int abc_control_corner_material = 2131230763;
+			
+			// aapt resource value: 0x7f08002c
+			public const int abc_control_inset_material = 2131230764;
+			
+			// aapt resource value: 0x7f08002d
+			public const int abc_control_padding_material = 2131230765;
+			
+			// aapt resource value: 0x7f080010
+			public const int abc_dialog_fixed_height_major = 2131230736;
+			
+			// aapt resource value: 0x7f080011
+			public const int abc_dialog_fixed_height_minor = 2131230737;
+			
+			// aapt resource value: 0x7f080012
+			public const int abc_dialog_fixed_width_major = 2131230738;
+			
+			// aapt resource value: 0x7f080013
+			public const int abc_dialog_fixed_width_minor = 2131230739;
+			
+			// aapt resource value: 0x7f08002e
+			public const int abc_dialog_list_padding_vertical_material = 2131230766;
+			
+			// aapt resource value: 0x7f080014
+			public const int abc_dialog_min_width_major = 2131230740;
+			
+			// aapt resource value: 0x7f080015
+			public const int abc_dialog_min_width_minor = 2131230741;
+			
+			// aapt resource value: 0x7f08002f
+			public const int abc_dialog_padding_material = 2131230767;
+			
+			// aapt resource value: 0x7f080030
+			public const int abc_dialog_padding_top_material = 2131230768;
+			
+			// aapt resource value: 0x7f080031
+			public const int abc_disabled_alpha_material_dark = 2131230769;
+			
+			// aapt resource value: 0x7f080032
+			public const int abc_disabled_alpha_material_light = 2131230770;
+			
+			// aapt resource value: 0x7f080033
+			public const int abc_dropdownitem_icon_width = 2131230771;
+			
+			// aapt resource value: 0x7f080034
+			public const int abc_dropdownitem_text_padding_left = 2131230772;
+			
+			// aapt resource value: 0x7f080035
+			public const int abc_dropdownitem_text_padding_right = 2131230773;
+			
+			// aapt resource value: 0x7f080036
+			public const int abc_edit_text_inset_bottom_material = 2131230774;
+			
+			// aapt resource value: 0x7f080037
+			public const int abc_edit_text_inset_horizontal_material = 2131230775;
+			
+			// aapt resource value: 0x7f080038
+			public const int abc_edit_text_inset_top_material = 2131230776;
+			
+			// aapt resource value: 0x7f080039
+			public const int abc_floating_window_z = 2131230777;
+			
+			// aapt resource value: 0x7f08003a
+			public const int abc_list_item_padding_horizontal_material = 2131230778;
+			
+			// aapt resource value: 0x7f08003b
+			public const int abc_panel_menu_list_width = 2131230779;
+			
+			// aapt resource value: 0x7f08003c
+			public const int abc_progress_bar_height_material = 2131230780;
+			
+			// aapt resource value: 0x7f08003d
+			public const int abc_search_view_preferred_height = 2131230781;
+			
+			// aapt resource value: 0x7f08003e
+			public const int abc_search_view_preferred_width = 2131230782;
+			
+			// aapt resource value: 0x7f08003f
+			public const int abc_seekbar_track_background_height_material = 2131230783;
+			
+			// aapt resource value: 0x7f080040
+			public const int abc_seekbar_track_progress_height_material = 2131230784;
+			
+			// aapt resource value: 0x7f080041
+			public const int abc_select_dialog_padding_start_material = 2131230785;
+			
+			// aapt resource value: 0x7f08001a
+			public const int abc_switch_padding = 2131230746;
+			
+			// aapt resource value: 0x7f080042
+			public const int abc_text_size_body_1_material = 2131230786;
+			
+			// aapt resource value: 0x7f080043
+			public const int abc_text_size_body_2_material = 2131230787;
+			
+			// aapt resource value: 0x7f080044
+			public const int abc_text_size_button_material = 2131230788;
+			
+			// aapt resource value: 0x7f080045
+			public const int abc_text_size_caption_material = 2131230789;
+			
+			// aapt resource value: 0x7f080046
+			public const int abc_text_size_display_1_material = 2131230790;
+			
+			// aapt resource value: 0x7f080047
+			public const int abc_text_size_display_2_material = 2131230791;
+			
+			// aapt resource value: 0x7f080048
+			public const int abc_text_size_display_3_material = 2131230792;
+			
+			// aapt resource value: 0x7f080049
+			public const int abc_text_size_display_4_material = 2131230793;
+			
+			// aapt resource value: 0x7f08004a
+			public const int abc_text_size_headline_material = 2131230794;
+			
+			// aapt resource value: 0x7f08004b
+			public const int abc_text_size_large_material = 2131230795;
+			
+			// aapt resource value: 0x7f08004c
+			public const int abc_text_size_medium_material = 2131230796;
+			
+			// aapt resource value: 0x7f08004d
+			public const int abc_text_size_menu_header_material = 2131230797;
+			
+			// aapt resource value: 0x7f08004e
+			public const int abc_text_size_menu_material = 2131230798;
+			
+			// aapt resource value: 0x7f08004f
+			public const int abc_text_size_small_material = 2131230799;
+			
+			// aapt resource value: 0x7f080050
+			public const int abc_text_size_subhead_material = 2131230800;
+			
+			// aapt resource value: 0x7f08000d
+			public const int abc_text_size_subtitle_material_toolbar = 2131230733;
+			
+			// aapt resource value: 0x7f080051
+			public const int abc_text_size_title_material = 2131230801;
+			
+			// aapt resource value: 0x7f08000e
+			public const int abc_text_size_title_material_toolbar = 2131230734;
+			
+			// aapt resource value: 0x7f080052
+			public const int disabled_alpha_material_dark = 2131230802;
+			
+			// aapt resource value: 0x7f080053
+			public const int disabled_alpha_material_light = 2131230803;
+			
+			// aapt resource value: 0x7f080054
+			public const int highlight_alpha_material_colored = 2131230804;
+			
+			// aapt resource value: 0x7f080055
+			public const int highlight_alpha_material_dark = 2131230805;
+			
+			// aapt resource value: 0x7f080056
+			public const int highlight_alpha_material_light = 2131230806;
+			
+			// aapt resource value: 0x7f080057
+			public const int notification_large_icon_height = 2131230807;
+			
+			// aapt resource value: 0x7f080058
+			public const int notification_large_icon_width = 2131230808;
+			
+			// aapt resource value: 0x7f080059
+			public const int notification_subtext_size = 2131230809;
+			
+			// aapt resource value: 0x7f080000
+			public const int place_autocomplete_button_padding = 2131230720;
+			
+			// aapt resource value: 0x7f080001
+			public const int place_autocomplete_powered_by_google_height = 2131230721;
+			
+			// aapt resource value: 0x7f080002
+			public const int place_autocomplete_powered_by_google_start = 2131230722;
+			
+			// aapt resource value: 0x7f080003
+			public const int place_autocomplete_prediction_height = 2131230723;
+			
+			// aapt resource value: 0x7f080004
+			public const int place_autocomplete_prediction_horizontal_margin = 2131230724;
+			
+			// aapt resource value: 0x7f080005
+			public const int place_autocomplete_prediction_primary_text = 2131230725;
+			
+			// aapt resource value: 0x7f080006
+			public const int place_autocomplete_prediction_secondary_text = 2131230726;
+			
+			// aapt resource value: 0x7f080007
+			public const int place_autocomplete_progress_horizontal_margin = 2131230727;
+			
+			// aapt resource value: 0x7f080008
+			public const int place_autocomplete_progress_size = 2131230728;
+			
+			// aapt resource value: 0x7f080009
+			public const int place_autocomplete_separator_start = 2131230729;
+			
+			static Dimension()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Dimension()
+			{
+			}
+		}
+		
 		public partial class Drawable
 		{
 			
 			// aapt resource value: 0x7f020000
-			public const int Icon = 2130837504;
+			public const int abc_ab_share_pack_mtrl_alpha = 2130837504;
+			
+			// aapt resource value: 0x7f020001
+			public const int abc_action_bar_item_background_material = 2130837505;
+			
+			// aapt resource value: 0x7f020002
+			public const int abc_btn_borderless_material = 2130837506;
+			
+			// aapt resource value: 0x7f020003
+			public const int abc_btn_check_material = 2130837507;
+			
+			// aapt resource value: 0x7f020004
+			public const int abc_btn_check_to_on_mtrl_000 = 2130837508;
+			
+			// aapt resource value: 0x7f020005
+			public const int abc_btn_check_to_on_mtrl_015 = 2130837509;
+			
+			// aapt resource value: 0x7f020006
+			public const int abc_btn_colored_material = 2130837510;
+			
+			// aapt resource value: 0x7f020007
+			public const int abc_btn_default_mtrl_shape = 2130837511;
+			
+			// aapt resource value: 0x7f020008
+			public const int abc_btn_radio_material = 2130837512;
+			
+			// aapt resource value: 0x7f020009
+			public const int abc_btn_radio_to_on_mtrl_000 = 2130837513;
+			
+			// aapt resource value: 0x7f02000a
+			public const int abc_btn_radio_to_on_mtrl_015 = 2130837514;
+			
+			// aapt resource value: 0x7f02000b
+			public const int abc_btn_switch_to_on_mtrl_00001 = 2130837515;
+			
+			// aapt resource value: 0x7f02000c
+			public const int abc_btn_switch_to_on_mtrl_00012 = 2130837516;
+			
+			// aapt resource value: 0x7f02000d
+			public const int abc_cab_background_internal_bg = 2130837517;
+			
+			// aapt resource value: 0x7f02000e
+			public const int abc_cab_background_top_material = 2130837518;
+			
+			// aapt resource value: 0x7f02000f
+			public const int abc_cab_background_top_mtrl_alpha = 2130837519;
+			
+			// aapt resource value: 0x7f020010
+			public const int abc_control_background_material = 2130837520;
+			
+			// aapt resource value: 0x7f020011
+			public const int abc_dialog_material_background = 2130837521;
+			
+			// aapt resource value: 0x7f020012
+			public const int abc_edit_text_material = 2130837522;
+			
+			// aapt resource value: 0x7f020013
+			public const int abc_ic_ab_back_material = 2130837523;
+			
+			// aapt resource value: 0x7f020014
+			public const int abc_ic_arrow_drop_right_black_24dp = 2130837524;
+			
+			// aapt resource value: 0x7f020015
+			public const int abc_ic_clear_material = 2130837525;
+			
+			// aapt resource value: 0x7f020016
+			public const int abc_ic_commit_search_api_mtrl_alpha = 2130837526;
+			
+			// aapt resource value: 0x7f020017
+			public const int abc_ic_go_search_api_material = 2130837527;
+			
+			// aapt resource value: 0x7f020018
+			public const int abc_ic_menu_copy_mtrl_am_alpha = 2130837528;
+			
+			// aapt resource value: 0x7f020019
+			public const int abc_ic_menu_cut_mtrl_alpha = 2130837529;
+			
+			// aapt resource value: 0x7f02001a
+			public const int abc_ic_menu_overflow_material = 2130837530;
+			
+			// aapt resource value: 0x7f02001b
+			public const int abc_ic_menu_paste_mtrl_am_alpha = 2130837531;
+			
+			// aapt resource value: 0x7f02001c
+			public const int abc_ic_menu_selectall_mtrl_alpha = 2130837532;
+			
+			// aapt resource value: 0x7f02001d
+			public const int abc_ic_menu_share_mtrl_alpha = 2130837533;
+			
+			// aapt resource value: 0x7f02001e
+			public const int abc_ic_search_api_material = 2130837534;
+			
+			// aapt resource value: 0x7f02001f
+			public const int abc_ic_star_black_16dp = 2130837535;
+			
+			// aapt resource value: 0x7f020020
+			public const int abc_ic_star_black_36dp = 2130837536;
+			
+			// aapt resource value: 0x7f020021
+			public const int abc_ic_star_black_48dp = 2130837537;
+			
+			// aapt resource value: 0x7f020022
+			public const int abc_ic_star_half_black_16dp = 2130837538;
+			
+			// aapt resource value: 0x7f020023
+			public const int abc_ic_star_half_black_36dp = 2130837539;
+			
+			// aapt resource value: 0x7f020024
+			public const int abc_ic_star_half_black_48dp = 2130837540;
+			
+			// aapt resource value: 0x7f020025
+			public const int abc_ic_voice_search_api_material = 2130837541;
+			
+			// aapt resource value: 0x7f020026
+			public const int abc_item_background_holo_dark = 2130837542;
+			
+			// aapt resource value: 0x7f020027
+			public const int abc_item_background_holo_light = 2130837543;
+			
+			// aapt resource value: 0x7f020028
+			public const int abc_list_divider_mtrl_alpha = 2130837544;
+			
+			// aapt resource value: 0x7f020029
+			public const int abc_list_focused_holo = 2130837545;
+			
+			// aapt resource value: 0x7f02002a
+			public const int abc_list_longpressed_holo = 2130837546;
+			
+			// aapt resource value: 0x7f02002b
+			public const int abc_list_pressed_holo_dark = 2130837547;
+			
+			// aapt resource value: 0x7f02002c
+			public const int abc_list_pressed_holo_light = 2130837548;
+			
+			// aapt resource value: 0x7f02002d
+			public const int abc_list_selector_background_transition_holo_dark = 2130837549;
+			
+			// aapt resource value: 0x7f02002e
+			public const int abc_list_selector_background_transition_holo_light = 2130837550;
+			
+			// aapt resource value: 0x7f02002f
+			public const int abc_list_selector_disabled_holo_dark = 2130837551;
+			
+			// aapt resource value: 0x7f020030
+			public const int abc_list_selector_disabled_holo_light = 2130837552;
+			
+			// aapt resource value: 0x7f020031
+			public const int abc_list_selector_holo_dark = 2130837553;
+			
+			// aapt resource value: 0x7f020032
+			public const int abc_list_selector_holo_light = 2130837554;
+			
+			// aapt resource value: 0x7f020033
+			public const int abc_menu_hardkey_panel_mtrl_mult = 2130837555;
+			
+			// aapt resource value: 0x7f020034
+			public const int abc_popup_background_mtrl_mult = 2130837556;
+			
+			// aapt resource value: 0x7f020035
+			public const int abc_ratingbar_indicator_material = 2130837557;
+			
+			// aapt resource value: 0x7f020036
+			public const int abc_ratingbar_material = 2130837558;
+			
+			// aapt resource value: 0x7f020037
+			public const int abc_ratingbar_small_material = 2130837559;
+			
+			// aapt resource value: 0x7f020038
+			public const int abc_scrubber_control_off_mtrl_alpha = 2130837560;
+			
+			// aapt resource value: 0x7f020039
+			public const int abc_scrubber_control_to_pressed_mtrl_000 = 2130837561;
+			
+			// aapt resource value: 0x7f02003a
+			public const int abc_scrubber_control_to_pressed_mtrl_005 = 2130837562;
+			
+			// aapt resource value: 0x7f02003b
+			public const int abc_scrubber_primary_mtrl_alpha = 2130837563;
+			
+			// aapt resource value: 0x7f02003c
+			public const int abc_scrubber_track_mtrl_alpha = 2130837564;
+			
+			// aapt resource value: 0x7f02003d
+			public const int abc_seekbar_thumb_material = 2130837565;
+			
+			// aapt resource value: 0x7f02003e
+			public const int abc_seekbar_tick_mark_material = 2130837566;
+			
+			// aapt resource value: 0x7f02003f
+			public const int abc_seekbar_track_material = 2130837567;
+			
+			// aapt resource value: 0x7f020040
+			public const int abc_spinner_mtrl_am_alpha = 2130837568;
+			
+			// aapt resource value: 0x7f020041
+			public const int abc_spinner_textfield_background_material = 2130837569;
+			
+			// aapt resource value: 0x7f020042
+			public const int abc_switch_thumb_material = 2130837570;
+			
+			// aapt resource value: 0x7f020043
+			public const int abc_switch_track_mtrl_alpha = 2130837571;
+			
+			// aapt resource value: 0x7f020044
+			public const int abc_tab_indicator_material = 2130837572;
+			
+			// aapt resource value: 0x7f020045
+			public const int abc_tab_indicator_mtrl_alpha = 2130837573;
+			
+			// aapt resource value: 0x7f020046
+			public const int abc_text_cursor_material = 2130837574;
+			
+			// aapt resource value: 0x7f020047
+			public const int abc_text_select_handle_left_mtrl_dark = 2130837575;
+			
+			// aapt resource value: 0x7f020048
+			public const int abc_text_select_handle_left_mtrl_light = 2130837576;
+			
+			// aapt resource value: 0x7f020049
+			public const int abc_text_select_handle_middle_mtrl_dark = 2130837577;
+			
+			// aapt resource value: 0x7f02004a
+			public const int abc_text_select_handle_middle_mtrl_light = 2130837578;
+			
+			// aapt resource value: 0x7f02004b
+			public const int abc_text_select_handle_right_mtrl_dark = 2130837579;
+			
+			// aapt resource value: 0x7f02004c
+			public const int abc_text_select_handle_right_mtrl_light = 2130837580;
+			
+			// aapt resource value: 0x7f02004d
+			public const int abc_textfield_activated_mtrl_alpha = 2130837581;
+			
+			// aapt resource value: 0x7f02004e
+			public const int abc_textfield_default_mtrl_alpha = 2130837582;
+			
+			// aapt resource value: 0x7f02004f
+			public const int abc_textfield_search_activated_mtrl_alpha = 2130837583;
+			
+			// aapt resource value: 0x7f020050
+			public const int abc_textfield_search_default_mtrl_alpha = 2130837584;
+			
+			// aapt resource value: 0x7f020051
+			public const int abc_textfield_search_material = 2130837585;
+			
+			// aapt resource value: 0x7f020052
+			public const int abc_vector_test = 2130837586;
+			
+			// aapt resource value: 0x7f020053
+			public const int common_full_open_on_phone = 2130837587;
+			
+			// aapt resource value: 0x7f020054
+			public const int common_google_signin_btn_icon_dark = 2130837588;
+			
+			// aapt resource value: 0x7f020055
+			public const int common_google_signin_btn_icon_dark_disabled = 2130837589;
+			
+			// aapt resource value: 0x7f020056
+			public const int common_google_signin_btn_icon_dark_focused = 2130837590;
+			
+			// aapt resource value: 0x7f020057
+			public const int common_google_signin_btn_icon_dark_normal = 2130837591;
+			
+			// aapt resource value: 0x7f020058
+			public const int common_google_signin_btn_icon_dark_pressed = 2130837592;
+			
+			// aapt resource value: 0x7f020059
+			public const int common_google_signin_btn_icon_light = 2130837593;
+			
+			// aapt resource value: 0x7f02005a
+			public const int common_google_signin_btn_icon_light_disabled = 2130837594;
+			
+			// aapt resource value: 0x7f02005b
+			public const int common_google_signin_btn_icon_light_focused = 2130837595;
+			
+			// aapt resource value: 0x7f02005c
+			public const int common_google_signin_btn_icon_light_normal = 2130837596;
+			
+			// aapt resource value: 0x7f02005d
+			public const int common_google_signin_btn_icon_light_pressed = 2130837597;
+			
+			// aapt resource value: 0x7f02005e
+			public const int common_google_signin_btn_text_dark = 2130837598;
+			
+			// aapt resource value: 0x7f02005f
+			public const int common_google_signin_btn_text_dark_disabled = 2130837599;
+			
+			// aapt resource value: 0x7f020060
+			public const int common_google_signin_btn_text_dark_focused = 2130837600;
+			
+			// aapt resource value: 0x7f020061
+			public const int common_google_signin_btn_text_dark_normal = 2130837601;
+			
+			// aapt resource value: 0x7f020062
+			public const int common_google_signin_btn_text_dark_pressed = 2130837602;
+			
+			// aapt resource value: 0x7f020063
+			public const int common_google_signin_btn_text_light = 2130837603;
+			
+			// aapt resource value: 0x7f020064
+			public const int common_google_signin_btn_text_light_disabled = 2130837604;
+			
+			// aapt resource value: 0x7f020065
+			public const int common_google_signin_btn_text_light_focused = 2130837605;
+			
+			// aapt resource value: 0x7f020066
+			public const int common_google_signin_btn_text_light_normal = 2130837606;
+			
+			// aapt resource value: 0x7f020067
+			public const int common_google_signin_btn_text_light_pressed = 2130837607;
+			
+			// aapt resource value: 0x7f020068
+			public const int common_ic_googleplayservices = 2130837608;
+			
+			// aapt resource value: 0x7f020069
+			public const int Icon = 2130837609;
+			
+			// aapt resource value: 0x7f02006e
+			public const int notification_template_icon_bg = 2130837614;
+			
+			// aapt resource value: 0x7f02006a
+			public const int places_ic_clear = 2130837610;
+			
+			// aapt resource value: 0x7f02006b
+			public const int places_ic_search = 2130837611;
+			
+			// aapt resource value: 0x7f02006c
+			public const int powered_by_google_dark = 2130837612;
+			
+			// aapt resource value: 0x7f02006d
+			public const int powered_by_google_light = 2130837613;
 			
 			static Drawable()
 			{
@@ -82,59 +1823,407 @@ namespace UnitTests
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f050001
-			public const int OptionHostName = 2131034113;
+			// aapt resource value: 0x7f0b006d
+			public const int OptionHostName = 2131427437;
 			
-			// aapt resource value: 0x7f050002
-			public const int OptionPort = 2131034114;
+			// aapt resource value: 0x7f0b006e
+			public const int OptionPort = 2131427438;
 			
-			// aapt resource value: 0x7f050000
-			public const int OptionRemoteServer = 2131034112;
+			// aapt resource value: 0x7f0b006c
+			public const int OptionRemoteServer = 2131427436;
 			
-			// aapt resource value: 0x7f050010
-			public const int OptionsButton = 2131034128;
+			// aapt resource value: 0x7f0b0084
+			public const int OptionsButton = 2131427460;
 			
-			// aapt resource value: 0x7f05000b
-			public const int ResultFullName = 2131034123;
+			// aapt resource value: 0x7f0b007f
+			public const int ResultFullName = 2131427455;
 			
-			// aapt resource value: 0x7f05000d
-			public const int ResultMessage = 2131034125;
+			// aapt resource value: 0x7f0b0081
+			public const int ResultMessage = 2131427457;
 			
-			// aapt resource value: 0x7f05000c
-			public const int ResultResultState = 2131034124;
+			// aapt resource value: 0x7f0b0080
+			public const int ResultResultState = 2131427456;
 			
-			// aapt resource value: 0x7f05000a
-			public const int ResultRunSingleMethodTest = 2131034122;
+			// aapt resource value: 0x7f0b007e
+			public const int ResultRunSingleMethodTest = 2131427454;
 			
-			// aapt resource value: 0x7f05000e
-			public const int ResultStackTrace = 2131034126;
+			// aapt resource value: 0x7f0b0082
+			public const int ResultStackTrace = 2131427458;
 			
-			// aapt resource value: 0x7f050006
-			public const int ResultsFailed = 2131034118;
+			// aapt resource value: 0x7f0b007a
+			public const int ResultsFailed = 2131427450;
 			
-			// aapt resource value: 0x7f050003
-			public const int ResultsId = 2131034115;
+			// aapt resource value: 0x7f0b0077
+			public const int ResultsId = 2131427447;
 			
-			// aapt resource value: 0x7f050007
-			public const int ResultsIgnored = 2131034119;
+			// aapt resource value: 0x7f0b007b
+			public const int ResultsIgnored = 2131427451;
 			
-			// aapt resource value: 0x7f050008
-			public const int ResultsInconclusive = 2131034120;
+			// aapt resource value: 0x7f0b007c
+			public const int ResultsInconclusive = 2131427452;
 			
-			// aapt resource value: 0x7f050009
-			public const int ResultsMessage = 2131034121;
+			// aapt resource value: 0x7f0b007d
+			public const int ResultsMessage = 2131427453;
 			
-			// aapt resource value: 0x7f050005
-			public const int ResultsPassed = 2131034117;
+			// aapt resource value: 0x7f0b0079
+			public const int ResultsPassed = 2131427449;
 			
-			// aapt resource value: 0x7f050004
-			public const int ResultsResult = 2131034116;
+			// aapt resource value: 0x7f0b0078
+			public const int ResultsResult = 2131427448;
 			
-			// aapt resource value: 0x7f05000f
-			public const int RunTestsButton = 2131034127;
+			// aapt resource value: 0x7f0b0083
+			public const int RunTestsButton = 2131427459;
 			
-			// aapt resource value: 0x7f050011
-			public const int TestSuiteListView = 2131034129;
+			// aapt resource value: 0x7f0b0085
+			public const int TestSuiteListView = 2131427461;
+			
+			// aapt resource value: 0x7f0b005f
+			public const int action0 = 2131427423;
+			
+			// aapt resource value: 0x7f0b0050
+			public const int action_bar = 2131427408;
+			
+			// aapt resource value: 0x7f0b0000
+			public const int action_bar_activity_content = 2131427328;
+			
+			// aapt resource value: 0x7f0b004f
+			public const int action_bar_container = 2131427407;
+			
+			// aapt resource value: 0x7f0b004b
+			public const int action_bar_root = 2131427403;
+			
+			// aapt resource value: 0x7f0b0001
+			public const int action_bar_spinner = 2131427329;
+			
+			// aapt resource value: 0x7f0b0030
+			public const int action_bar_subtitle = 2131427376;
+			
+			// aapt resource value: 0x7f0b002f
+			public const int action_bar_title = 2131427375;
+			
+			// aapt resource value: 0x7f0b0051
+			public const int action_context_bar = 2131427409;
+			
+			// aapt resource value: 0x7f0b0063
+			public const int action_divider = 2131427427;
+			
+			// aapt resource value: 0x7f0b0002
+			public const int action_menu_divider = 2131427330;
+			
+			// aapt resource value: 0x7f0b0003
+			public const int action_menu_presenter = 2131427331;
+			
+			// aapt resource value: 0x7f0b004d
+			public const int action_mode_bar = 2131427405;
+			
+			// aapt resource value: 0x7f0b004c
+			public const int action_mode_bar_stub = 2131427404;
+			
+			// aapt resource value: 0x7f0b0031
+			public const int action_mode_close_button = 2131427377;
+			
+			// aapt resource value: 0x7f0b0032
+			public const int activity_chooser_view_content = 2131427378;
+			
+			// aapt resource value: 0x7f0b001e
+			public const int add = 2131427358;
+			
+			// aapt resource value: 0x7f0b0009
+			public const int adjust_height = 2131427337;
+			
+			// aapt resource value: 0x7f0b000a
+			public const int adjust_width = 2131427338;
+			
+			// aapt resource value: 0x7f0b003e
+			public const int alertTitle = 2131427390;
+			
+			// aapt resource value: 0x7f0b0028
+			public const int always = 2131427368;
+			
+			// aapt resource value: 0x7f0b000f
+			public const int auto = 2131427343;
+			
+			// aapt resource value: 0x7f0b0025
+			public const int beginning = 2131427365;
+			
+			// aapt resource value: 0x7f0b002d
+			public const int bottom = 2131427373;
+			
+			// aapt resource value: 0x7f0b0039
+			public const int buttonPanel = 2131427385;
+			
+			// aapt resource value: 0x7f0b0060
+			public const int cancel_action = 2131427424;
+			
+			// aapt resource value: 0x7f0b0047
+			public const int checkbox = 2131427399;
+			
+			// aapt resource value: 0x7f0b0066
+			public const int chronometer = 2131427430;
+			
+			// aapt resource value: 0x7f0b0029
+			public const int collapseActionView = 2131427369;
+			
+			// aapt resource value: 0x7f0b003f
+			public const int contentPanel = 2131427391;
+			
+			// aapt resource value: 0x7f0b0045
+			public const int custom = 2131427397;
+			
+			// aapt resource value: 0x7f0b0044
+			public const int customPanel = 2131427396;
+			
+			// aapt resource value: 0x7f0b0010
+			public const int dark = 2131427344;
+			
+			// aapt resource value: 0x7f0b004e
+			public const int decor_content_parent = 2131427406;
+			
+			// aapt resource value: 0x7f0b0035
+			public const int default_activity_button = 2131427381;
+			
+			// aapt resource value: 0x7f0b0018
+			public const int disableHome = 2131427352;
+			
+			// aapt resource value: 0x7f0b0052
+			public const int edit_query = 2131427410;
+			
+			// aapt resource value: 0x7f0b0026
+			public const int end = 2131427366;
+			
+			// aapt resource value: 0x7f0b006b
+			public const int end_padder = 2131427435;
+			
+			// aapt resource value: 0x7f0b0033
+			public const int expand_activities_button = 2131427379;
+			
+			// aapt resource value: 0x7f0b0046
+			public const int expanded_menu = 2131427398;
+			
+			// aapt resource value: 0x7f0b0004
+			public const int home = 2131427332;
+			
+			// aapt resource value: 0x7f0b0019
+			public const int homeAsUp = 2131427353;
+			
+			// aapt resource value: 0x7f0b0012
+			public const int hybrid = 2131427346;
+			
+			// aapt resource value: 0x7f0b0037
+			public const int icon = 2131427383;
+			
+			// aapt resource value: 0x7f0b000c
+			public const int icon_only = 2131427340;
+			
+			// aapt resource value: 0x7f0b002a
+			public const int ifRoom = 2131427370;
+			
+			// aapt resource value: 0x7f0b0034
+			public const int image = 2131427380;
+			
+			// aapt resource value: 0x7f0b006a
+			public const int info = 2131427434;
+			
+			// aapt resource value: 0x7f0b0011
+			public const int light = 2131427345;
+			
+			// aapt resource value: 0x7f0b0064
+			public const int line1 = 2131427428;
+			
+			// aapt resource value: 0x7f0b0068
+			public const int line3 = 2131427432;
+			
+			// aapt resource value: 0x7f0b0016
+			public const int listMode = 2131427350;
+			
+			// aapt resource value: 0x7f0b0036
+			public const int list_item = 2131427382;
+			
+			// aapt resource value: 0x7f0b0062
+			public const int media_actions = 2131427426;
+			
+			// aapt resource value: 0x7f0b0027
+			public const int middle = 2131427367;
+			
+			// aapt resource value: 0x7f0b001f
+			public const int multiply = 2131427359;
+			
+			// aapt resource value: 0x7f0b002b
+			public const int never = 2131427371;
+			
+			// aapt resource value: 0x7f0b000b
+			public const int none = 2131427339;
+			
+			// aapt resource value: 0x7f0b0013
+			public const int normal = 2131427347;
+			
+			// aapt resource value: 0x7f0b003b
+			public const int parentPanel = 2131427387;
+			
+			// aapt resource value: 0x7f0b0071
+			public const int place_autocomplete_clear_button = 2131427441;
+			
+			// aapt resource value: 0x7f0b0073
+			public const int place_autocomplete_powered_by_google = 2131427443;
+			
+			// aapt resource value: 0x7f0b0075
+			public const int place_autocomplete_prediction_primary_text = 2131427445;
+			
+			// aapt resource value: 0x7f0b0076
+			public const int place_autocomplete_prediction_secondary_text = 2131427446;
+			
+			// aapt resource value: 0x7f0b0074
+			public const int place_autocomplete_progress = 2131427444;
+			
+			// aapt resource value: 0x7f0b006f
+			public const int place_autocomplete_search_button = 2131427439;
+			
+			// aapt resource value: 0x7f0b0070
+			public const int place_autocomplete_search_input = 2131427440;
+			
+			// aapt resource value: 0x7f0b0072
+			public const int place_autocomplete_separator = 2131427442;
+			
+			// aapt resource value: 0x7f0b0005
+			public const int progress_circular = 2131427333;
+			
+			// aapt resource value: 0x7f0b0006
+			public const int progress_horizontal = 2131427334;
+			
+			// aapt resource value: 0x7f0b0049
+			public const int radio = 2131427401;
+			
+			// aapt resource value: 0x7f0b0014
+			public const int satellite = 2131427348;
+			
+			// aapt resource value: 0x7f0b0020
+			public const int screen = 2131427360;
+			
+			// aapt resource value: 0x7f0b0043
+			public const int scrollIndicatorDown = 2131427395;
+			
+			// aapt resource value: 0x7f0b0040
+			public const int scrollIndicatorUp = 2131427392;
+			
+			// aapt resource value: 0x7f0b0041
+			public const int scrollView = 2131427393;
+			
+			// aapt resource value: 0x7f0b0054
+			public const int search_badge = 2131427412;
+			
+			// aapt resource value: 0x7f0b0053
+			public const int search_bar = 2131427411;
+			
+			// aapt resource value: 0x7f0b0055
+			public const int search_button = 2131427413;
+			
+			// aapt resource value: 0x7f0b005a
+			public const int search_close_btn = 2131427418;
+			
+			// aapt resource value: 0x7f0b0056
+			public const int search_edit_frame = 2131427414;
+			
+			// aapt resource value: 0x7f0b005c
+			public const int search_go_btn = 2131427420;
+			
+			// aapt resource value: 0x7f0b0057
+			public const int search_mag_icon = 2131427415;
+			
+			// aapt resource value: 0x7f0b0058
+			public const int search_plate = 2131427416;
+			
+			// aapt resource value: 0x7f0b0059
+			public const int search_src_text = 2131427417;
+			
+			// aapt resource value: 0x7f0b005d
+			public const int search_voice_btn = 2131427421;
+			
+			// aapt resource value: 0x7f0b005e
+			public const int select_dialog_listview = 2131427422;
+			
+			// aapt resource value: 0x7f0b0048
+			public const int shortcut = 2131427400;
+			
+			// aapt resource value: 0x7f0b001a
+			public const int showCustom = 2131427354;
+			
+			// aapt resource value: 0x7f0b001b
+			public const int showHome = 2131427355;
+			
+			// aapt resource value: 0x7f0b001c
+			public const int showTitle = 2131427356;
+			
+			// aapt resource value: 0x7f0b003a
+			public const int spacer = 2131427386;
+			
+			// aapt resource value: 0x7f0b0007
+			public const int split_action_bar = 2131427335;
+			
+			// aapt resource value: 0x7f0b0021
+			public const int src_atop = 2131427361;
+			
+			// aapt resource value: 0x7f0b0022
+			public const int src_in = 2131427362;
+			
+			// aapt resource value: 0x7f0b0023
+			public const int src_over = 2131427363;
+			
+			// aapt resource value: 0x7f0b000d
+			public const int standard = 2131427341;
+			
+			// aapt resource value: 0x7f0b0061
+			public const int status_bar_latest_event_content = 2131427425;
+			
+			// aapt resource value: 0x7f0b004a
+			public const int submenuarrow = 2131427402;
+			
+			// aapt resource value: 0x7f0b005b
+			public const int submit_area = 2131427419;
+			
+			// aapt resource value: 0x7f0b0017
+			public const int tabMode = 2131427351;
+			
+			// aapt resource value: 0x7f0b0015
+			public const int terrain = 2131427349;
+			
+			// aapt resource value: 0x7f0b0069
+			public const int text = 2131427433;
+			
+			// aapt resource value: 0x7f0b0067
+			public const int text2 = 2131427431;
+			
+			// aapt resource value: 0x7f0b0042
+			public const int textSpacerNoButtons = 2131427394;
+			
+			// aapt resource value: 0x7f0b0065
+			public const int time = 2131427429;
+			
+			// aapt resource value: 0x7f0b0038
+			public const int title = 2131427384;
+			
+			// aapt resource value: 0x7f0b003d
+			public const int title_template = 2131427389;
+			
+			// aapt resource value: 0x7f0b002e
+			public const int top = 2131427374;
+			
+			// aapt resource value: 0x7f0b003c
+			public const int topPanel = 2131427388;
+			
+			// aapt resource value: 0x7f0b0008
+			public const int up = 2131427336;
+			
+			// aapt resource value: 0x7f0b001d
+			public const int useLogo = 2131427357;
+			
+			// aapt resource value: 0x7f0b000e
+			public const int wide = 2131427342;
+			
+			// aapt resource value: 0x7f0b002c
+			public const int withText = 2131427372;
+			
+			// aapt resource value: 0x7f0b0024
+			public const int wrap_content = 2131427364;
 			
 			static Id()
 			{
@@ -146,20 +2235,174 @@ namespace UnitTests
 			}
 		}
 		
+		public partial class Integer
+		{
+			
+			// aapt resource value: 0x7f050001
+			public const int abc_config_activityDefaultDur = 2131034113;
+			
+			// aapt resource value: 0x7f050002
+			public const int abc_config_activityShortDur = 2131034114;
+			
+			// aapt resource value: 0x7f050003
+			public const int cancel_button_image_alpha = 2131034115;
+			
+			// aapt resource value: 0x7f050000
+			public const int google_play_services_version = 2131034112;
+			
+			// aapt resource value: 0x7f050004
+			public const int status_bar_notification_info_maxnum = 2131034116;
+			
+			static Integer()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Integer()
+			{
+			}
+		}
+		
 		public partial class Layout
 		{
 			
 			// aapt resource value: 0x7f030000
-			public const int options = 2130903040;
+			public const int abc_action_bar_title_item = 2130903040;
 			
 			// aapt resource value: 0x7f030001
-			public const int results = 2130903041;
+			public const int abc_action_bar_up_container = 2130903041;
 			
 			// aapt resource value: 0x7f030002
-			public const int test_result = 2130903042;
+			public const int abc_action_bar_view_list_nav_layout = 2130903042;
 			
 			// aapt resource value: 0x7f030003
-			public const int test_suite = 2130903043;
+			public const int abc_action_menu_item_layout = 2130903043;
+			
+			// aapt resource value: 0x7f030004
+			public const int abc_action_menu_layout = 2130903044;
+			
+			// aapt resource value: 0x7f030005
+			public const int abc_action_mode_bar = 2130903045;
+			
+			// aapt resource value: 0x7f030006
+			public const int abc_action_mode_close_item_material = 2130903046;
+			
+			// aapt resource value: 0x7f030007
+			public const int abc_activity_chooser_view = 2130903047;
+			
+			// aapt resource value: 0x7f030008
+			public const int abc_activity_chooser_view_list_item = 2130903048;
+			
+			// aapt resource value: 0x7f030009
+			public const int abc_alert_dialog_button_bar_material = 2130903049;
+			
+			// aapt resource value: 0x7f03000a
+			public const int abc_alert_dialog_material = 2130903050;
+			
+			// aapt resource value: 0x7f03000b
+			public const int abc_dialog_title_material = 2130903051;
+			
+			// aapt resource value: 0x7f03000c
+			public const int abc_expanded_menu_layout = 2130903052;
+			
+			// aapt resource value: 0x7f03000d
+			public const int abc_list_menu_item_checkbox = 2130903053;
+			
+			// aapt resource value: 0x7f03000e
+			public const int abc_list_menu_item_icon = 2130903054;
+			
+			// aapt resource value: 0x7f03000f
+			public const int abc_list_menu_item_layout = 2130903055;
+			
+			// aapt resource value: 0x7f030010
+			public const int abc_list_menu_item_radio = 2130903056;
+			
+			// aapt resource value: 0x7f030011
+			public const int abc_popup_menu_header_item_layout = 2130903057;
+			
+			// aapt resource value: 0x7f030012
+			public const int abc_popup_menu_item_layout = 2130903058;
+			
+			// aapt resource value: 0x7f030013
+			public const int abc_screen_content_include = 2130903059;
+			
+			// aapt resource value: 0x7f030014
+			public const int abc_screen_simple = 2130903060;
+			
+			// aapt resource value: 0x7f030015
+			public const int abc_screen_simple_overlay_action_mode = 2130903061;
+			
+			// aapt resource value: 0x7f030016
+			public const int abc_screen_toolbar = 2130903062;
+			
+			// aapt resource value: 0x7f030017
+			public const int abc_search_dropdown_item_icons_2line = 2130903063;
+			
+			// aapt resource value: 0x7f030018
+			public const int abc_search_view = 2130903064;
+			
+			// aapt resource value: 0x7f030019
+			public const int abc_select_dialog_material = 2130903065;
+			
+			// aapt resource value: 0x7f03001a
+			public const int notification_media_action = 2130903066;
+			
+			// aapt resource value: 0x7f03001b
+			public const int notification_media_cancel_action = 2130903067;
+			
+			// aapt resource value: 0x7f03001c
+			public const int notification_template_big_media = 2130903068;
+			
+			// aapt resource value: 0x7f03001d
+			public const int notification_template_big_media_narrow = 2130903069;
+			
+			// aapt resource value: 0x7f03001e
+			public const int notification_template_lines = 2130903070;
+			
+			// aapt resource value: 0x7f03001f
+			public const int notification_template_media = 2130903071;
+			
+			// aapt resource value: 0x7f030020
+			public const int notification_template_part_chronometer = 2130903072;
+			
+			// aapt resource value: 0x7f030021
+			public const int notification_template_part_time = 2130903073;
+			
+			// aapt resource value: 0x7f030022
+			public const int options = 2130903074;
+			
+			// aapt resource value: 0x7f030023
+			public const int place_autocomplete_fragment = 2130903075;
+			
+			// aapt resource value: 0x7f030024
+			public const int place_autocomplete_item_powered_by_google = 2130903076;
+			
+			// aapt resource value: 0x7f030025
+			public const int place_autocomplete_item_prediction = 2130903077;
+			
+			// aapt resource value: 0x7f030026
+			public const int place_autocomplete_progress = 2130903078;
+			
+			// aapt resource value: 0x7f030027
+			public const int results = 2130903079;
+			
+			// aapt resource value: 0x7f030028
+			public const int select_dialog_item_material = 2130903080;
+			
+			// aapt resource value: 0x7f030029
+			public const int select_dialog_multichoice_material = 2130903081;
+			
+			// aapt resource value: 0x7f03002a
+			public const int select_dialog_singlechoice_material = 2130903082;
+			
+			// aapt resource value: 0x7f03002b
+			public const int support_simple_spinner_dropdown_item = 2130903083;
+			
+			// aapt resource value: 0x7f03002c
+			public const int test_result = 2130903084;
+			
+			// aapt resource value: 0x7f03002d
+			public const int test_suite = 2130903085;
 			
 			static Layout()
 			{
@@ -174,11 +2417,176 @@ namespace UnitTests
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f040001
-			public const int ApplicationName = 2130968577;
+			// aapt resource value: 0x7f060038
+			public const int ApplicationName = 2131099704;
 			
-			// aapt resource value: 0x7f040000
-			public const int Hello = 2130968576;
+			// aapt resource value: 0x7f060037
+			public const int Hello = 2131099703;
+			
+			// aapt resource value: 0x7f060016
+			public const int abc_action_bar_home_description = 2131099670;
+			
+			// aapt resource value: 0x7f060017
+			public const int abc_action_bar_home_description_format = 2131099671;
+			
+			// aapt resource value: 0x7f060018
+			public const int abc_action_bar_home_subtitle_description_format = 2131099672;
+			
+			// aapt resource value: 0x7f060019
+			public const int abc_action_bar_up_description = 2131099673;
+			
+			// aapt resource value: 0x7f06001a
+			public const int abc_action_menu_overflow_description = 2131099674;
+			
+			// aapt resource value: 0x7f06001b
+			public const int abc_action_mode_done = 2131099675;
+			
+			// aapt resource value: 0x7f06001c
+			public const int abc_activity_chooser_view_see_all = 2131099676;
+			
+			// aapt resource value: 0x7f06001d
+			public const int abc_activitychooserview_choose_application = 2131099677;
+			
+			// aapt resource value: 0x7f06001e
+			public const int abc_capital_off = 2131099678;
+			
+			// aapt resource value: 0x7f06001f
+			public const int abc_capital_on = 2131099679;
+			
+			// aapt resource value: 0x7f06002b
+			public const int abc_font_family_body_1_material = 2131099691;
+			
+			// aapt resource value: 0x7f06002c
+			public const int abc_font_family_body_2_material = 2131099692;
+			
+			// aapt resource value: 0x7f06002d
+			public const int abc_font_family_button_material = 2131099693;
+			
+			// aapt resource value: 0x7f06002e
+			public const int abc_font_family_caption_material = 2131099694;
+			
+			// aapt resource value: 0x7f06002f
+			public const int abc_font_family_display_1_material = 2131099695;
+			
+			// aapt resource value: 0x7f060030
+			public const int abc_font_family_display_2_material = 2131099696;
+			
+			// aapt resource value: 0x7f060031
+			public const int abc_font_family_display_3_material = 2131099697;
+			
+			// aapt resource value: 0x7f060032
+			public const int abc_font_family_display_4_material = 2131099698;
+			
+			// aapt resource value: 0x7f060033
+			public const int abc_font_family_headline_material = 2131099699;
+			
+			// aapt resource value: 0x7f060034
+			public const int abc_font_family_menu_material = 2131099700;
+			
+			// aapt resource value: 0x7f060035
+			public const int abc_font_family_subhead_material = 2131099701;
+			
+			// aapt resource value: 0x7f060036
+			public const int abc_font_family_title_material = 2131099702;
+			
+			// aapt resource value: 0x7f060020
+			public const int abc_search_hint = 2131099680;
+			
+			// aapt resource value: 0x7f060021
+			public const int abc_searchview_description_clear = 2131099681;
+			
+			// aapt resource value: 0x7f060022
+			public const int abc_searchview_description_query = 2131099682;
+			
+			// aapt resource value: 0x7f060023
+			public const int abc_searchview_description_search = 2131099683;
+			
+			// aapt resource value: 0x7f060024
+			public const int abc_searchview_description_submit = 2131099684;
+			
+			// aapt resource value: 0x7f060025
+			public const int abc_searchview_description_voice = 2131099685;
+			
+			// aapt resource value: 0x7f060026
+			public const int abc_shareactionprovider_share_with = 2131099686;
+			
+			// aapt resource value: 0x7f060027
+			public const int abc_shareactionprovider_share_with_application = 2131099687;
+			
+			// aapt resource value: 0x7f060028
+			public const int abc_toolbar_collapse_description = 2131099688;
+			
+			// aapt resource value: 0x7f060003
+			public const int common_google_play_services_enable_button = 2131099651;
+			
+			// aapt resource value: 0x7f060004
+			public const int common_google_play_services_enable_text = 2131099652;
+			
+			// aapt resource value: 0x7f060005
+			public const int common_google_play_services_enable_title = 2131099653;
+			
+			// aapt resource value: 0x7f060006
+			public const int common_google_play_services_install_button = 2131099654;
+			
+			// aapt resource value: 0x7f060007
+			public const int common_google_play_services_install_text_phone = 2131099655;
+			
+			// aapt resource value: 0x7f060008
+			public const int common_google_play_services_install_text_tablet = 2131099656;
+			
+			// aapt resource value: 0x7f060009
+			public const int common_google_play_services_install_title = 2131099657;
+			
+			// aapt resource value: 0x7f06000a
+			public const int common_google_play_services_notification_ticker = 2131099658;
+			
+			// aapt resource value: 0x7f060000
+			public const int common_google_play_services_unknown_issue = 2131099648;
+			
+			// aapt resource value: 0x7f06000b
+			public const int common_google_play_services_unsupported_text = 2131099659;
+			
+			// aapt resource value: 0x7f06000c
+			public const int common_google_play_services_unsupported_title = 2131099660;
+			
+			// aapt resource value: 0x7f06000d
+			public const int common_google_play_services_update_button = 2131099661;
+			
+			// aapt resource value: 0x7f06000e
+			public const int common_google_play_services_update_text = 2131099662;
+			
+			// aapt resource value: 0x7f06000f
+			public const int common_google_play_services_update_title = 2131099663;
+			
+			// aapt resource value: 0x7f060010
+			public const int common_google_play_services_updating_text = 2131099664;
+			
+			// aapt resource value: 0x7f060011
+			public const int common_google_play_services_updating_title = 2131099665;
+			
+			// aapt resource value: 0x7f060012
+			public const int common_google_play_services_wear_update_text = 2131099666;
+			
+			// aapt resource value: 0x7f060013
+			public const int common_open_on_phone = 2131099667;
+			
+			// aapt resource value: 0x7f060014
+			public const int common_signin_button_text = 2131099668;
+			
+			// aapt resource value: 0x7f060015
+			public const int common_signin_button_text_long = 2131099669;
+			
+			// aapt resource value: 0x7f060001
+			public const int place_autocomplete_clear_button = 2131099649;
+			
+			// aapt resource value: 0x7f060002
+			public const int place_autocomplete_search_hint = 2131099650;
+			
+			// aapt resource value: 0x7f060029
+			public const int search_menu_title = 2131099689;
+			
+			// aapt resource value: 0x7f06002a
+			public const int status_bar_notification_info_overflow = 2131099690;
 			
 			static String()
 			{
@@ -186,6 +2594,2515 @@ namespace UnitTests
 			}
 			
 			private String()
+			{
+			}
+		}
+		
+		public partial class Style
+		{
+			
+			// aapt resource value: 0x7f09008a
+			public const int AlertDialog_AppCompat = 2131296394;
+			
+			// aapt resource value: 0x7f09008b
+			public const int AlertDialog_AppCompat_Light = 2131296395;
+			
+			// aapt resource value: 0x7f09008c
+			public const int Animation_AppCompat_Dialog = 2131296396;
+			
+			// aapt resource value: 0x7f09008d
+			public const int Animation_AppCompat_DropDownUp = 2131296397;
+			
+			// aapt resource value: 0x7f09008e
+			public const int Base_AlertDialog_AppCompat = 2131296398;
+			
+			// aapt resource value: 0x7f09008f
+			public const int Base_AlertDialog_AppCompat_Light = 2131296399;
+			
+			// aapt resource value: 0x7f090090
+			public const int Base_Animation_AppCompat_Dialog = 2131296400;
+			
+			// aapt resource value: 0x7f090091
+			public const int Base_Animation_AppCompat_DropDownUp = 2131296401;
+			
+			// aapt resource value: 0x7f090092
+			public const int Base_DialogWindowTitle_AppCompat = 2131296402;
+			
+			// aapt resource value: 0x7f090093
+			public const int Base_DialogWindowTitleBackground_AppCompat = 2131296403;
+			
+			// aapt resource value: 0x7f090038
+			public const int Base_TextAppearance_AppCompat = 2131296312;
+			
+			// aapt resource value: 0x7f090039
+			public const int Base_TextAppearance_AppCompat_Body1 = 2131296313;
+			
+			// aapt resource value: 0x7f09003a
+			public const int Base_TextAppearance_AppCompat_Body2 = 2131296314;
+			
+			// aapt resource value: 0x7f090022
+			public const int Base_TextAppearance_AppCompat_Button = 2131296290;
+			
+			// aapt resource value: 0x7f09003b
+			public const int Base_TextAppearance_AppCompat_Caption = 2131296315;
+			
+			// aapt resource value: 0x7f09003c
+			public const int Base_TextAppearance_AppCompat_Display1 = 2131296316;
+			
+			// aapt resource value: 0x7f09003d
+			public const int Base_TextAppearance_AppCompat_Display2 = 2131296317;
+			
+			// aapt resource value: 0x7f09003e
+			public const int Base_TextAppearance_AppCompat_Display3 = 2131296318;
+			
+			// aapt resource value: 0x7f09003f
+			public const int Base_TextAppearance_AppCompat_Display4 = 2131296319;
+			
+			// aapt resource value: 0x7f090040
+			public const int Base_TextAppearance_AppCompat_Headline = 2131296320;
+			
+			// aapt resource value: 0x7f09000b
+			public const int Base_TextAppearance_AppCompat_Inverse = 2131296267;
+			
+			// aapt resource value: 0x7f090041
+			public const int Base_TextAppearance_AppCompat_Large = 2131296321;
+			
+			// aapt resource value: 0x7f09000c
+			public const int Base_TextAppearance_AppCompat_Large_Inverse = 2131296268;
+			
+			// aapt resource value: 0x7f090042
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296322;
+			
+			// aapt resource value: 0x7f090043
+			public const int Base_TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296323;
+			
+			// aapt resource value: 0x7f090044
+			public const int Base_TextAppearance_AppCompat_Medium = 2131296324;
+			
+			// aapt resource value: 0x7f09000d
+			public const int Base_TextAppearance_AppCompat_Medium_Inverse = 2131296269;
+			
+			// aapt resource value: 0x7f090045
+			public const int Base_TextAppearance_AppCompat_Menu = 2131296325;
+			
+			// aapt resource value: 0x7f090094
+			public const int Base_TextAppearance_AppCompat_SearchResult = 2131296404;
+			
+			// aapt resource value: 0x7f090046
+			public const int Base_TextAppearance_AppCompat_SearchResult_Subtitle = 2131296326;
+			
+			// aapt resource value: 0x7f090047
+			public const int Base_TextAppearance_AppCompat_SearchResult_Title = 2131296327;
+			
+			// aapt resource value: 0x7f090048
+			public const int Base_TextAppearance_AppCompat_Small = 2131296328;
+			
+			// aapt resource value: 0x7f09000e
+			public const int Base_TextAppearance_AppCompat_Small_Inverse = 2131296270;
+			
+			// aapt resource value: 0x7f090049
+			public const int Base_TextAppearance_AppCompat_Subhead = 2131296329;
+			
+			// aapt resource value: 0x7f09000f
+			public const int Base_TextAppearance_AppCompat_Subhead_Inverse = 2131296271;
+			
+			// aapt resource value: 0x7f09004a
+			public const int Base_TextAppearance_AppCompat_Title = 2131296330;
+			
+			// aapt resource value: 0x7f090010
+			public const int Base_TextAppearance_AppCompat_Title_Inverse = 2131296272;
+			
+			// aapt resource value: 0x7f090083
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296387;
+			
+			// aapt resource value: 0x7f09004b
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296331;
+			
+			// aapt resource value: 0x7f09004c
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296332;
+			
+			// aapt resource value: 0x7f09004d
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296333;
+			
+			// aapt resource value: 0x7f09004e
+			public const int Base_TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296334;
+			
+			// aapt resource value: 0x7f09004f
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296335;
+			
+			// aapt resource value: 0x7f090050
+			public const int Base_TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296336;
+			
+			// aapt resource value: 0x7f090051
+			public const int Base_TextAppearance_AppCompat_Widget_Button = 2131296337;
+			
+			// aapt resource value: 0x7f090084
+			public const int Base_TextAppearance_AppCompat_Widget_Button_Inverse = 2131296388;
+			
+			// aapt resource value: 0x7f090095
+			public const int Base_TextAppearance_AppCompat_Widget_DropDownItem = 2131296405;
+			
+			// aapt resource value: 0x7f090052
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131296338;
+			
+			// aapt resource value: 0x7f090053
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296339;
+			
+			// aapt resource value: 0x7f090054
+			public const int Base_TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296340;
+			
+			// aapt resource value: 0x7f090055
+			public const int Base_TextAppearance_AppCompat_Widget_Switch = 2131296341;
+			
+			// aapt resource value: 0x7f090056
+			public const int Base_TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296342;
+			
+			// aapt resource value: 0x7f090096
+			public const int Base_TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296406;
+			
+			// aapt resource value: 0x7f090057
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296343;
+			
+			// aapt resource value: 0x7f090058
+			public const int Base_TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296344;
+			
+			// aapt resource value: 0x7f090059
+			public const int Base_Theme_AppCompat = 2131296345;
+			
+			// aapt resource value: 0x7f090097
+			public const int Base_Theme_AppCompat_CompactMenu = 2131296407;
+			
+			// aapt resource value: 0x7f090011
+			public const int Base_Theme_AppCompat_Dialog = 2131296273;
+			
+			// aapt resource value: 0x7f090098
+			public const int Base_Theme_AppCompat_Dialog_Alert = 2131296408;
+			
+			// aapt resource value: 0x7f090099
+			public const int Base_Theme_AppCompat_Dialog_FixedSize = 2131296409;
+			
+			// aapt resource value: 0x7f09009a
+			public const int Base_Theme_AppCompat_Dialog_MinWidth = 2131296410;
+			
+			// aapt resource value: 0x7f090001
+			public const int Base_Theme_AppCompat_DialogWhenLarge = 2131296257;
+			
+			// aapt resource value: 0x7f09005a
+			public const int Base_Theme_AppCompat_Light = 2131296346;
+			
+			// aapt resource value: 0x7f09009b
+			public const int Base_Theme_AppCompat_Light_DarkActionBar = 2131296411;
+			
+			// aapt resource value: 0x7f090012
+			public const int Base_Theme_AppCompat_Light_Dialog = 2131296274;
+			
+			// aapt resource value: 0x7f09009c
+			public const int Base_Theme_AppCompat_Light_Dialog_Alert = 2131296412;
+			
+			// aapt resource value: 0x7f09009d
+			public const int Base_Theme_AppCompat_Light_Dialog_FixedSize = 2131296413;
+			
+			// aapt resource value: 0x7f09009e
+			public const int Base_Theme_AppCompat_Light_Dialog_MinWidth = 2131296414;
+			
+			// aapt resource value: 0x7f090002
+			public const int Base_Theme_AppCompat_Light_DialogWhenLarge = 2131296258;
+			
+			// aapt resource value: 0x7f09009f
+			public const int Base_ThemeOverlay_AppCompat = 2131296415;
+			
+			// aapt resource value: 0x7f0900a0
+			public const int Base_ThemeOverlay_AppCompat_ActionBar = 2131296416;
+			
+			// aapt resource value: 0x7f0900a1
+			public const int Base_ThemeOverlay_AppCompat_Dark = 2131296417;
+			
+			// aapt resource value: 0x7f0900a2
+			public const int Base_ThemeOverlay_AppCompat_Dark_ActionBar = 2131296418;
+			
+			// aapt resource value: 0x7f090013
+			public const int Base_ThemeOverlay_AppCompat_Dialog = 2131296275;
+			
+			// aapt resource value: 0x7f0900a3
+			public const int Base_ThemeOverlay_AppCompat_Dialog_Alert = 2131296419;
+			
+			// aapt resource value: 0x7f0900a4
+			public const int Base_ThemeOverlay_AppCompat_Light = 2131296420;
+			
+			// aapt resource value: 0x7f090014
+			public const int Base_V11_Theme_AppCompat_Dialog = 2131296276;
+			
+			// aapt resource value: 0x7f090015
+			public const int Base_V11_Theme_AppCompat_Light_Dialog = 2131296277;
+			
+			// aapt resource value: 0x7f090016
+			public const int Base_V11_ThemeOverlay_AppCompat_Dialog = 2131296278;
+			
+			// aapt resource value: 0x7f09001e
+			public const int Base_V12_Widget_AppCompat_AutoCompleteTextView = 2131296286;
+			
+			// aapt resource value: 0x7f09001f
+			public const int Base_V12_Widget_AppCompat_EditText = 2131296287;
+			
+			// aapt resource value: 0x7f09005b
+			public const int Base_V21_Theme_AppCompat = 2131296347;
+			
+			// aapt resource value: 0x7f09005c
+			public const int Base_V21_Theme_AppCompat_Dialog = 2131296348;
+			
+			// aapt resource value: 0x7f09005d
+			public const int Base_V21_Theme_AppCompat_Light = 2131296349;
+			
+			// aapt resource value: 0x7f09005e
+			public const int Base_V21_Theme_AppCompat_Light_Dialog = 2131296350;
+			
+			// aapt resource value: 0x7f09005f
+			public const int Base_V21_ThemeOverlay_AppCompat_Dialog = 2131296351;
+			
+			// aapt resource value: 0x7f090081
+			public const int Base_V22_Theme_AppCompat = 2131296385;
+			
+			// aapt resource value: 0x7f090082
+			public const int Base_V22_Theme_AppCompat_Light = 2131296386;
+			
+			// aapt resource value: 0x7f090085
+			public const int Base_V23_Theme_AppCompat = 2131296389;
+			
+			// aapt resource value: 0x7f090086
+			public const int Base_V23_Theme_AppCompat_Light = 2131296390;
+			
+			// aapt resource value: 0x7f0900a5
+			public const int Base_V7_Theme_AppCompat = 2131296421;
+			
+			// aapt resource value: 0x7f0900a6
+			public const int Base_V7_Theme_AppCompat_Dialog = 2131296422;
+			
+			// aapt resource value: 0x7f0900a7
+			public const int Base_V7_Theme_AppCompat_Light = 2131296423;
+			
+			// aapt resource value: 0x7f0900a8
+			public const int Base_V7_Theme_AppCompat_Light_Dialog = 2131296424;
+			
+			// aapt resource value: 0x7f0900a9
+			public const int Base_V7_ThemeOverlay_AppCompat_Dialog = 2131296425;
+			
+			// aapt resource value: 0x7f0900aa
+			public const int Base_V7_Widget_AppCompat_AutoCompleteTextView = 2131296426;
+			
+			// aapt resource value: 0x7f0900ab
+			public const int Base_V7_Widget_AppCompat_EditText = 2131296427;
+			
+			// aapt resource value: 0x7f0900ac
+			public const int Base_Widget_AppCompat_ActionBar = 2131296428;
+			
+			// aapt resource value: 0x7f0900ad
+			public const int Base_Widget_AppCompat_ActionBar_Solid = 2131296429;
+			
+			// aapt resource value: 0x7f0900ae
+			public const int Base_Widget_AppCompat_ActionBar_TabBar = 2131296430;
+			
+			// aapt resource value: 0x7f090060
+			public const int Base_Widget_AppCompat_ActionBar_TabText = 2131296352;
+			
+			// aapt resource value: 0x7f090061
+			public const int Base_Widget_AppCompat_ActionBar_TabView = 2131296353;
+			
+			// aapt resource value: 0x7f090062
+			public const int Base_Widget_AppCompat_ActionButton = 2131296354;
+			
+			// aapt resource value: 0x7f090063
+			public const int Base_Widget_AppCompat_ActionButton_CloseMode = 2131296355;
+			
+			// aapt resource value: 0x7f090064
+			public const int Base_Widget_AppCompat_ActionButton_Overflow = 2131296356;
+			
+			// aapt resource value: 0x7f0900af
+			public const int Base_Widget_AppCompat_ActionMode = 2131296431;
+			
+			// aapt resource value: 0x7f0900b0
+			public const int Base_Widget_AppCompat_ActivityChooserView = 2131296432;
+			
+			// aapt resource value: 0x7f090020
+			public const int Base_Widget_AppCompat_AutoCompleteTextView = 2131296288;
+			
+			// aapt resource value: 0x7f090065
+			public const int Base_Widget_AppCompat_Button = 2131296357;
+			
+			// aapt resource value: 0x7f090066
+			public const int Base_Widget_AppCompat_Button_Borderless = 2131296358;
+			
+			// aapt resource value: 0x7f090067
+			public const int Base_Widget_AppCompat_Button_Borderless_Colored = 2131296359;
+			
+			// aapt resource value: 0x7f0900b1
+			public const int Base_Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296433;
+			
+			// aapt resource value: 0x7f090087
+			public const int Base_Widget_AppCompat_Button_Colored = 2131296391;
+			
+			// aapt resource value: 0x7f090068
+			public const int Base_Widget_AppCompat_Button_Small = 2131296360;
+			
+			// aapt resource value: 0x7f090069
+			public const int Base_Widget_AppCompat_ButtonBar = 2131296361;
+			
+			// aapt resource value: 0x7f0900b2
+			public const int Base_Widget_AppCompat_ButtonBar_AlertDialog = 2131296434;
+			
+			// aapt resource value: 0x7f09006a
+			public const int Base_Widget_AppCompat_CompoundButton_CheckBox = 2131296362;
+			
+			// aapt resource value: 0x7f09006b
+			public const int Base_Widget_AppCompat_CompoundButton_RadioButton = 2131296363;
+			
+			// aapt resource value: 0x7f0900b3
+			public const int Base_Widget_AppCompat_CompoundButton_Switch = 2131296435;
+			
+			// aapt resource value: 0x7f090000
+			public const int Base_Widget_AppCompat_DrawerArrowToggle = 2131296256;
+			
+			// aapt resource value: 0x7f0900b4
+			public const int Base_Widget_AppCompat_DrawerArrowToggle_Common = 2131296436;
+			
+			// aapt resource value: 0x7f09006c
+			public const int Base_Widget_AppCompat_DropDownItem_Spinner = 2131296364;
+			
+			// aapt resource value: 0x7f090021
+			public const int Base_Widget_AppCompat_EditText = 2131296289;
+			
+			// aapt resource value: 0x7f09006d
+			public const int Base_Widget_AppCompat_ImageButton = 2131296365;
+			
+			// aapt resource value: 0x7f0900b5
+			public const int Base_Widget_AppCompat_Light_ActionBar = 2131296437;
+			
+			// aapt resource value: 0x7f0900b6
+			public const int Base_Widget_AppCompat_Light_ActionBar_Solid = 2131296438;
+			
+			// aapt resource value: 0x7f0900b7
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabBar = 2131296439;
+			
+			// aapt resource value: 0x7f09006e
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText = 2131296366;
+			
+			// aapt resource value: 0x7f09006f
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296367;
+			
+			// aapt resource value: 0x7f090070
+			public const int Base_Widget_AppCompat_Light_ActionBar_TabView = 2131296368;
+			
+			// aapt resource value: 0x7f090071
+			public const int Base_Widget_AppCompat_Light_PopupMenu = 2131296369;
+			
+			// aapt resource value: 0x7f090072
+			public const int Base_Widget_AppCompat_Light_PopupMenu_Overflow = 2131296370;
+			
+			// aapt resource value: 0x7f0900b8
+			public const int Base_Widget_AppCompat_ListMenuView = 2131296440;
+			
+			// aapt resource value: 0x7f090073
+			public const int Base_Widget_AppCompat_ListPopupWindow = 2131296371;
+			
+			// aapt resource value: 0x7f090074
+			public const int Base_Widget_AppCompat_ListView = 2131296372;
+			
+			// aapt resource value: 0x7f090075
+			public const int Base_Widget_AppCompat_ListView_DropDown = 2131296373;
+			
+			// aapt resource value: 0x7f090076
+			public const int Base_Widget_AppCompat_ListView_Menu = 2131296374;
+			
+			// aapt resource value: 0x7f090077
+			public const int Base_Widget_AppCompat_PopupMenu = 2131296375;
+			
+			// aapt resource value: 0x7f090078
+			public const int Base_Widget_AppCompat_PopupMenu_Overflow = 2131296376;
+			
+			// aapt resource value: 0x7f0900b9
+			public const int Base_Widget_AppCompat_PopupWindow = 2131296441;
+			
+			// aapt resource value: 0x7f090017
+			public const int Base_Widget_AppCompat_ProgressBar = 2131296279;
+			
+			// aapt resource value: 0x7f090018
+			public const int Base_Widget_AppCompat_ProgressBar_Horizontal = 2131296280;
+			
+			// aapt resource value: 0x7f090079
+			public const int Base_Widget_AppCompat_RatingBar = 2131296377;
+			
+			// aapt resource value: 0x7f090088
+			public const int Base_Widget_AppCompat_RatingBar_Indicator = 2131296392;
+			
+			// aapt resource value: 0x7f090089
+			public const int Base_Widget_AppCompat_RatingBar_Small = 2131296393;
+			
+			// aapt resource value: 0x7f0900ba
+			public const int Base_Widget_AppCompat_SearchView = 2131296442;
+			
+			// aapt resource value: 0x7f0900bb
+			public const int Base_Widget_AppCompat_SearchView_ActionBar = 2131296443;
+			
+			// aapt resource value: 0x7f09007a
+			public const int Base_Widget_AppCompat_SeekBar = 2131296378;
+			
+			// aapt resource value: 0x7f0900bc
+			public const int Base_Widget_AppCompat_SeekBar_Discrete = 2131296444;
+			
+			// aapt resource value: 0x7f09007b
+			public const int Base_Widget_AppCompat_Spinner = 2131296379;
+			
+			// aapt resource value: 0x7f090003
+			public const int Base_Widget_AppCompat_Spinner_Underlined = 2131296259;
+			
+			// aapt resource value: 0x7f09007c
+			public const int Base_Widget_AppCompat_TextView_SpinnerItem = 2131296380;
+			
+			// aapt resource value: 0x7f0900bd
+			public const int Base_Widget_AppCompat_Toolbar = 2131296445;
+			
+			// aapt resource value: 0x7f09007d
+			public const int Base_Widget_AppCompat_Toolbar_Button_Navigation = 2131296381;
+			
+			// aapt resource value: 0x7f090019
+			public const int Platform_AppCompat = 2131296281;
+			
+			// aapt resource value: 0x7f09001a
+			public const int Platform_AppCompat_Light = 2131296282;
+			
+			// aapt resource value: 0x7f09007e
+			public const int Platform_ThemeOverlay_AppCompat = 2131296382;
+			
+			// aapt resource value: 0x7f09007f
+			public const int Platform_ThemeOverlay_AppCompat_Dark = 2131296383;
+			
+			// aapt resource value: 0x7f090080
+			public const int Platform_ThemeOverlay_AppCompat_Light = 2131296384;
+			
+			// aapt resource value: 0x7f09001b
+			public const int Platform_V11_AppCompat = 2131296283;
+			
+			// aapt resource value: 0x7f09001c
+			public const int Platform_V11_AppCompat_Light = 2131296284;
+			
+			// aapt resource value: 0x7f090023
+			public const int Platform_V14_AppCompat = 2131296291;
+			
+			// aapt resource value: 0x7f090024
+			public const int Platform_V14_AppCompat_Light = 2131296292;
+			
+			// aapt resource value: 0x7f09001d
+			public const int Platform_Widget_AppCompat_Spinner = 2131296285;
+			
+			// aapt resource value: 0x7f09002a
+			public const int RtlOverlay_DialogWindowTitle_AppCompat = 2131296298;
+			
+			// aapt resource value: 0x7f09002b
+			public const int RtlOverlay_Widget_AppCompat_ActionBar_TitleItem = 2131296299;
+			
+			// aapt resource value: 0x7f09002c
+			public const int RtlOverlay_Widget_AppCompat_DialogTitle_Icon = 2131296300;
+			
+			// aapt resource value: 0x7f09002d
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem = 2131296301;
+			
+			// aapt resource value: 0x7f09002e
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_InternalGroup = 2131296302;
+			
+			// aapt resource value: 0x7f09002f
+			public const int RtlOverlay_Widget_AppCompat_PopupMenuItem_Text = 2131296303;
+			
+			// aapt resource value: 0x7f090030
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown = 2131296304;
+			
+			// aapt resource value: 0x7f090031
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon1 = 2131296305;
+			
+			// aapt resource value: 0x7f090032
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Icon2 = 2131296306;
+			
+			// aapt resource value: 0x7f090033
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Query = 2131296307;
+			
+			// aapt resource value: 0x7f090034
+			public const int RtlOverlay_Widget_AppCompat_Search_DropDown_Text = 2131296308;
+			
+			// aapt resource value: 0x7f090035
+			public const int RtlOverlay_Widget_AppCompat_SearchView_MagIcon = 2131296309;
+			
+			// aapt resource value: 0x7f090036
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton = 2131296310;
+			
+			// aapt resource value: 0x7f090037
+			public const int RtlUnderlay_Widget_AppCompat_ActionButton_Overflow = 2131296311;
+			
+			// aapt resource value: 0x7f0900be
+			public const int TextAppearance_AppCompat = 2131296446;
+			
+			// aapt resource value: 0x7f0900bf
+			public const int TextAppearance_AppCompat_Body1 = 2131296447;
+			
+			// aapt resource value: 0x7f0900c0
+			public const int TextAppearance_AppCompat_Body2 = 2131296448;
+			
+			// aapt resource value: 0x7f0900c1
+			public const int TextAppearance_AppCompat_Button = 2131296449;
+			
+			// aapt resource value: 0x7f0900c2
+			public const int TextAppearance_AppCompat_Caption = 2131296450;
+			
+			// aapt resource value: 0x7f0900c3
+			public const int TextAppearance_AppCompat_Display1 = 2131296451;
+			
+			// aapt resource value: 0x7f0900c4
+			public const int TextAppearance_AppCompat_Display2 = 2131296452;
+			
+			// aapt resource value: 0x7f0900c5
+			public const int TextAppearance_AppCompat_Display3 = 2131296453;
+			
+			// aapt resource value: 0x7f0900c6
+			public const int TextAppearance_AppCompat_Display4 = 2131296454;
+			
+			// aapt resource value: 0x7f0900c7
+			public const int TextAppearance_AppCompat_Headline = 2131296455;
+			
+			// aapt resource value: 0x7f0900c8
+			public const int TextAppearance_AppCompat_Inverse = 2131296456;
+			
+			// aapt resource value: 0x7f0900c9
+			public const int TextAppearance_AppCompat_Large = 2131296457;
+			
+			// aapt resource value: 0x7f0900ca
+			public const int TextAppearance_AppCompat_Large_Inverse = 2131296458;
+			
+			// aapt resource value: 0x7f0900cb
+			public const int TextAppearance_AppCompat_Light_SearchResult_Subtitle = 2131296459;
+			
+			// aapt resource value: 0x7f0900cc
+			public const int TextAppearance_AppCompat_Light_SearchResult_Title = 2131296460;
+			
+			// aapt resource value: 0x7f0900cd
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Large = 2131296461;
+			
+			// aapt resource value: 0x7f0900ce
+			public const int TextAppearance_AppCompat_Light_Widget_PopupMenu_Small = 2131296462;
+			
+			// aapt resource value: 0x7f0900cf
+			public const int TextAppearance_AppCompat_Medium = 2131296463;
+			
+			// aapt resource value: 0x7f0900d0
+			public const int TextAppearance_AppCompat_Medium_Inverse = 2131296464;
+			
+			// aapt resource value: 0x7f0900d1
+			public const int TextAppearance_AppCompat_Menu = 2131296465;
+			
+			// aapt resource value: 0x7f0900d2
+			public const int TextAppearance_AppCompat_SearchResult_Subtitle = 2131296466;
+			
+			// aapt resource value: 0x7f0900d3
+			public const int TextAppearance_AppCompat_SearchResult_Title = 2131296467;
+			
+			// aapt resource value: 0x7f0900d4
+			public const int TextAppearance_AppCompat_Small = 2131296468;
+			
+			// aapt resource value: 0x7f0900d5
+			public const int TextAppearance_AppCompat_Small_Inverse = 2131296469;
+			
+			// aapt resource value: 0x7f0900d6
+			public const int TextAppearance_AppCompat_Subhead = 2131296470;
+			
+			// aapt resource value: 0x7f0900d7
+			public const int TextAppearance_AppCompat_Subhead_Inverse = 2131296471;
+			
+			// aapt resource value: 0x7f0900d8
+			public const int TextAppearance_AppCompat_Title = 2131296472;
+			
+			// aapt resource value: 0x7f0900d9
+			public const int TextAppearance_AppCompat_Title_Inverse = 2131296473;
+			
+			// aapt resource value: 0x7f0900da
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Menu = 2131296474;
+			
+			// aapt resource value: 0x7f0900db
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle = 2131296475;
+			
+			// aapt resource value: 0x7f0900dc
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Subtitle_Inverse = 2131296476;
+			
+			// aapt resource value: 0x7f0900dd
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title = 2131296477;
+			
+			// aapt resource value: 0x7f0900de
+			public const int TextAppearance_AppCompat_Widget_ActionBar_Title_Inverse = 2131296478;
+			
+			// aapt resource value: 0x7f0900df
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle = 2131296479;
+			
+			// aapt resource value: 0x7f0900e0
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Subtitle_Inverse = 2131296480;
+			
+			// aapt resource value: 0x7f0900e1
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title = 2131296481;
+			
+			// aapt resource value: 0x7f0900e2
+			public const int TextAppearance_AppCompat_Widget_ActionMode_Title_Inverse = 2131296482;
+			
+			// aapt resource value: 0x7f0900e3
+			public const int TextAppearance_AppCompat_Widget_Button = 2131296483;
+			
+			// aapt resource value: 0x7f0900e4
+			public const int TextAppearance_AppCompat_Widget_Button_Inverse = 2131296484;
+			
+			// aapt resource value: 0x7f0900e5
+			public const int TextAppearance_AppCompat_Widget_DropDownItem = 2131296485;
+			
+			// aapt resource value: 0x7f0900e6
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Header = 2131296486;
+			
+			// aapt resource value: 0x7f0900e7
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Large = 2131296487;
+			
+			// aapt resource value: 0x7f0900e8
+			public const int TextAppearance_AppCompat_Widget_PopupMenu_Small = 2131296488;
+			
+			// aapt resource value: 0x7f0900e9
+			public const int TextAppearance_AppCompat_Widget_Switch = 2131296489;
+			
+			// aapt resource value: 0x7f0900ea
+			public const int TextAppearance_AppCompat_Widget_TextView_SpinnerItem = 2131296490;
+			
+			// aapt resource value: 0x7f090025
+			public const int TextAppearance_StatusBar_EventContent = 2131296293;
+			
+			// aapt resource value: 0x7f090026
+			public const int TextAppearance_StatusBar_EventContent_Info = 2131296294;
+			
+			// aapt resource value: 0x7f090027
+			public const int TextAppearance_StatusBar_EventContent_Line2 = 2131296295;
+			
+			// aapt resource value: 0x7f090028
+			public const int TextAppearance_StatusBar_EventContent_Time = 2131296296;
+			
+			// aapt resource value: 0x7f090029
+			public const int TextAppearance_StatusBar_EventContent_Title = 2131296297;
+			
+			// aapt resource value: 0x7f0900eb
+			public const int TextAppearance_Widget_AppCompat_ExpandedMenu_Item = 2131296491;
+			
+			// aapt resource value: 0x7f0900ec
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Subtitle = 2131296492;
+			
+			// aapt resource value: 0x7f0900ed
+			public const int TextAppearance_Widget_AppCompat_Toolbar_Title = 2131296493;
+			
+			// aapt resource value: 0x7f0900ee
+			public const int Theme_AppCompat = 2131296494;
+			
+			// aapt resource value: 0x7f0900ef
+			public const int Theme_AppCompat_CompactMenu = 2131296495;
+			
+			// aapt resource value: 0x7f090004
+			public const int Theme_AppCompat_DayNight = 2131296260;
+			
+			// aapt resource value: 0x7f090005
+			public const int Theme_AppCompat_DayNight_DarkActionBar = 2131296261;
+			
+			// aapt resource value: 0x7f090006
+			public const int Theme_AppCompat_DayNight_Dialog = 2131296262;
+			
+			// aapt resource value: 0x7f090007
+			public const int Theme_AppCompat_DayNight_Dialog_Alert = 2131296263;
+			
+			// aapt resource value: 0x7f090008
+			public const int Theme_AppCompat_DayNight_Dialog_MinWidth = 2131296264;
+			
+			// aapt resource value: 0x7f090009
+			public const int Theme_AppCompat_DayNight_DialogWhenLarge = 2131296265;
+			
+			// aapt resource value: 0x7f09000a
+			public const int Theme_AppCompat_DayNight_NoActionBar = 2131296266;
+			
+			// aapt resource value: 0x7f0900f0
+			public const int Theme_AppCompat_Dialog = 2131296496;
+			
+			// aapt resource value: 0x7f0900f1
+			public const int Theme_AppCompat_Dialog_Alert = 2131296497;
+			
+			// aapt resource value: 0x7f0900f2
+			public const int Theme_AppCompat_Dialog_MinWidth = 2131296498;
+			
+			// aapt resource value: 0x7f0900f3
+			public const int Theme_AppCompat_DialogWhenLarge = 2131296499;
+			
+			// aapt resource value: 0x7f0900f4
+			public const int Theme_AppCompat_Light = 2131296500;
+			
+			// aapt resource value: 0x7f0900f5
+			public const int Theme_AppCompat_Light_DarkActionBar = 2131296501;
+			
+			// aapt resource value: 0x7f0900f6
+			public const int Theme_AppCompat_Light_Dialog = 2131296502;
+			
+			// aapt resource value: 0x7f0900f7
+			public const int Theme_AppCompat_Light_Dialog_Alert = 2131296503;
+			
+			// aapt resource value: 0x7f0900f8
+			public const int Theme_AppCompat_Light_Dialog_MinWidth = 2131296504;
+			
+			// aapt resource value: 0x7f0900f9
+			public const int Theme_AppCompat_Light_DialogWhenLarge = 2131296505;
+			
+			// aapt resource value: 0x7f0900fa
+			public const int Theme_AppCompat_Light_NoActionBar = 2131296506;
+			
+			// aapt resource value: 0x7f0900fb
+			public const int Theme_AppCompat_NoActionBar = 2131296507;
+			
+			// aapt resource value: 0x7f0900fc
+			public const int ThemeOverlay_AppCompat = 2131296508;
+			
+			// aapt resource value: 0x7f0900fd
+			public const int ThemeOverlay_AppCompat_ActionBar = 2131296509;
+			
+			// aapt resource value: 0x7f0900fe
+			public const int ThemeOverlay_AppCompat_Dark = 2131296510;
+			
+			// aapt resource value: 0x7f0900ff
+			public const int ThemeOverlay_AppCompat_Dark_ActionBar = 2131296511;
+			
+			// aapt resource value: 0x7f090100
+			public const int ThemeOverlay_AppCompat_Dialog = 2131296512;
+			
+			// aapt resource value: 0x7f090101
+			public const int ThemeOverlay_AppCompat_Dialog_Alert = 2131296513;
+			
+			// aapt resource value: 0x7f090102
+			public const int ThemeOverlay_AppCompat_Light = 2131296514;
+			
+			// aapt resource value: 0x7f090103
+			public const int Widget_AppCompat_ActionBar = 2131296515;
+			
+			// aapt resource value: 0x7f090104
+			public const int Widget_AppCompat_ActionBar_Solid = 2131296516;
+			
+			// aapt resource value: 0x7f090105
+			public const int Widget_AppCompat_ActionBar_TabBar = 2131296517;
+			
+			// aapt resource value: 0x7f090106
+			public const int Widget_AppCompat_ActionBar_TabText = 2131296518;
+			
+			// aapt resource value: 0x7f090107
+			public const int Widget_AppCompat_ActionBar_TabView = 2131296519;
+			
+			// aapt resource value: 0x7f090108
+			public const int Widget_AppCompat_ActionButton = 2131296520;
+			
+			// aapt resource value: 0x7f090109
+			public const int Widget_AppCompat_ActionButton_CloseMode = 2131296521;
+			
+			// aapt resource value: 0x7f09010a
+			public const int Widget_AppCompat_ActionButton_Overflow = 2131296522;
+			
+			// aapt resource value: 0x7f09010b
+			public const int Widget_AppCompat_ActionMode = 2131296523;
+			
+			// aapt resource value: 0x7f09010c
+			public const int Widget_AppCompat_ActivityChooserView = 2131296524;
+			
+			// aapt resource value: 0x7f09010d
+			public const int Widget_AppCompat_AutoCompleteTextView = 2131296525;
+			
+			// aapt resource value: 0x7f09010e
+			public const int Widget_AppCompat_Button = 2131296526;
+			
+			// aapt resource value: 0x7f09010f
+			public const int Widget_AppCompat_Button_Borderless = 2131296527;
+			
+			// aapt resource value: 0x7f090110
+			public const int Widget_AppCompat_Button_Borderless_Colored = 2131296528;
+			
+			// aapt resource value: 0x7f090111
+			public const int Widget_AppCompat_Button_ButtonBar_AlertDialog = 2131296529;
+			
+			// aapt resource value: 0x7f090112
+			public const int Widget_AppCompat_Button_Colored = 2131296530;
+			
+			// aapt resource value: 0x7f090113
+			public const int Widget_AppCompat_Button_Small = 2131296531;
+			
+			// aapt resource value: 0x7f090114
+			public const int Widget_AppCompat_ButtonBar = 2131296532;
+			
+			// aapt resource value: 0x7f090115
+			public const int Widget_AppCompat_ButtonBar_AlertDialog = 2131296533;
+			
+			// aapt resource value: 0x7f090116
+			public const int Widget_AppCompat_CompoundButton_CheckBox = 2131296534;
+			
+			// aapt resource value: 0x7f090117
+			public const int Widget_AppCompat_CompoundButton_RadioButton = 2131296535;
+			
+			// aapt resource value: 0x7f090118
+			public const int Widget_AppCompat_CompoundButton_Switch = 2131296536;
+			
+			// aapt resource value: 0x7f090119
+			public const int Widget_AppCompat_DrawerArrowToggle = 2131296537;
+			
+			// aapt resource value: 0x7f09011a
+			public const int Widget_AppCompat_DropDownItem_Spinner = 2131296538;
+			
+			// aapt resource value: 0x7f09011b
+			public const int Widget_AppCompat_EditText = 2131296539;
+			
+			// aapt resource value: 0x7f09011c
+			public const int Widget_AppCompat_ImageButton = 2131296540;
+			
+			// aapt resource value: 0x7f09011d
+			public const int Widget_AppCompat_Light_ActionBar = 2131296541;
+			
+			// aapt resource value: 0x7f09011e
+			public const int Widget_AppCompat_Light_ActionBar_Solid = 2131296542;
+			
+			// aapt resource value: 0x7f09011f
+			public const int Widget_AppCompat_Light_ActionBar_Solid_Inverse = 2131296543;
+			
+			// aapt resource value: 0x7f090120
+			public const int Widget_AppCompat_Light_ActionBar_TabBar = 2131296544;
+			
+			// aapt resource value: 0x7f090121
+			public const int Widget_AppCompat_Light_ActionBar_TabBar_Inverse = 2131296545;
+			
+			// aapt resource value: 0x7f090122
+			public const int Widget_AppCompat_Light_ActionBar_TabText = 2131296546;
+			
+			// aapt resource value: 0x7f090123
+			public const int Widget_AppCompat_Light_ActionBar_TabText_Inverse = 2131296547;
+			
+			// aapt resource value: 0x7f090124
+			public const int Widget_AppCompat_Light_ActionBar_TabView = 2131296548;
+			
+			// aapt resource value: 0x7f090125
+			public const int Widget_AppCompat_Light_ActionBar_TabView_Inverse = 2131296549;
+			
+			// aapt resource value: 0x7f090126
+			public const int Widget_AppCompat_Light_ActionButton = 2131296550;
+			
+			// aapt resource value: 0x7f090127
+			public const int Widget_AppCompat_Light_ActionButton_CloseMode = 2131296551;
+			
+			// aapt resource value: 0x7f090128
+			public const int Widget_AppCompat_Light_ActionButton_Overflow = 2131296552;
+			
+			// aapt resource value: 0x7f090129
+			public const int Widget_AppCompat_Light_ActionMode_Inverse = 2131296553;
+			
+			// aapt resource value: 0x7f09012a
+			public const int Widget_AppCompat_Light_ActivityChooserView = 2131296554;
+			
+			// aapt resource value: 0x7f09012b
+			public const int Widget_AppCompat_Light_AutoCompleteTextView = 2131296555;
+			
+			// aapt resource value: 0x7f09012c
+			public const int Widget_AppCompat_Light_DropDownItem_Spinner = 2131296556;
+			
+			// aapt resource value: 0x7f09012d
+			public const int Widget_AppCompat_Light_ListPopupWindow = 2131296557;
+			
+			// aapt resource value: 0x7f09012e
+			public const int Widget_AppCompat_Light_ListView_DropDown = 2131296558;
+			
+			// aapt resource value: 0x7f09012f
+			public const int Widget_AppCompat_Light_PopupMenu = 2131296559;
+			
+			// aapt resource value: 0x7f090130
+			public const int Widget_AppCompat_Light_PopupMenu_Overflow = 2131296560;
+			
+			// aapt resource value: 0x7f090131
+			public const int Widget_AppCompat_Light_SearchView = 2131296561;
+			
+			// aapt resource value: 0x7f090132
+			public const int Widget_AppCompat_Light_Spinner_DropDown_ActionBar = 2131296562;
+			
+			// aapt resource value: 0x7f090133
+			public const int Widget_AppCompat_ListMenuView = 2131296563;
+			
+			// aapt resource value: 0x7f090134
+			public const int Widget_AppCompat_ListPopupWindow = 2131296564;
+			
+			// aapt resource value: 0x7f090135
+			public const int Widget_AppCompat_ListView = 2131296565;
+			
+			// aapt resource value: 0x7f090136
+			public const int Widget_AppCompat_ListView_DropDown = 2131296566;
+			
+			// aapt resource value: 0x7f090137
+			public const int Widget_AppCompat_ListView_Menu = 2131296567;
+			
+			// aapt resource value: 0x7f090138
+			public const int Widget_AppCompat_PopupMenu = 2131296568;
+			
+			// aapt resource value: 0x7f090139
+			public const int Widget_AppCompat_PopupMenu_Overflow = 2131296569;
+			
+			// aapt resource value: 0x7f09013a
+			public const int Widget_AppCompat_PopupWindow = 2131296570;
+			
+			// aapt resource value: 0x7f09013b
+			public const int Widget_AppCompat_ProgressBar = 2131296571;
+			
+			// aapt resource value: 0x7f09013c
+			public const int Widget_AppCompat_ProgressBar_Horizontal = 2131296572;
+			
+			// aapt resource value: 0x7f09013d
+			public const int Widget_AppCompat_RatingBar = 2131296573;
+			
+			// aapt resource value: 0x7f09013e
+			public const int Widget_AppCompat_RatingBar_Indicator = 2131296574;
+			
+			// aapt resource value: 0x7f09013f
+			public const int Widget_AppCompat_RatingBar_Small = 2131296575;
+			
+			// aapt resource value: 0x7f090140
+			public const int Widget_AppCompat_SearchView = 2131296576;
+			
+			// aapt resource value: 0x7f090141
+			public const int Widget_AppCompat_SearchView_ActionBar = 2131296577;
+			
+			// aapt resource value: 0x7f090142
+			public const int Widget_AppCompat_SeekBar = 2131296578;
+			
+			// aapt resource value: 0x7f090143
+			public const int Widget_AppCompat_SeekBar_Discrete = 2131296579;
+			
+			// aapt resource value: 0x7f090144
+			public const int Widget_AppCompat_Spinner = 2131296580;
+			
+			// aapt resource value: 0x7f090145
+			public const int Widget_AppCompat_Spinner_DropDown = 2131296581;
+			
+			// aapt resource value: 0x7f090146
+			public const int Widget_AppCompat_Spinner_DropDown_ActionBar = 2131296582;
+			
+			// aapt resource value: 0x7f090147
+			public const int Widget_AppCompat_Spinner_Underlined = 2131296583;
+			
+			// aapt resource value: 0x7f090148
+			public const int Widget_AppCompat_TextView_SpinnerItem = 2131296584;
+			
+			// aapt resource value: 0x7f090149
+			public const int Widget_AppCompat_Toolbar = 2131296585;
+			
+			// aapt resource value: 0x7f09014a
+			public const int Widget_AppCompat_Toolbar_Button_Navigation = 2131296586;
+			
+			static Style()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Style()
+			{
+			}
+		}
+		
+		public partial class Styleable
+		{
+			
+			public static int[] ActionBar = new int[] {
+					2130771998,
+					2130772000,
+					2130772001,
+					2130772002,
+					2130772003,
+					2130772004,
+					2130772005,
+					2130772006,
+					2130772007,
+					2130772008,
+					2130772009,
+					2130772010,
+					2130772011,
+					2130772012,
+					2130772013,
+					2130772014,
+					2130772015,
+					2130772016,
+					2130772017,
+					2130772018,
+					2130772019,
+					2130772020,
+					2130772021,
+					2130772022,
+					2130772023,
+					2130772024,
+					2130772025,
+					2130772026,
+					2130772087};
+			
+			// aapt resource value: 10
+			public const int ActionBar_background = 10;
+			
+			// aapt resource value: 12
+			public const int ActionBar_backgroundSplit = 12;
+			
+			// aapt resource value: 11
+			public const int ActionBar_backgroundStacked = 11;
+			
+			// aapt resource value: 21
+			public const int ActionBar_contentInsetEnd = 21;
+			
+			// aapt resource value: 25
+			public const int ActionBar_contentInsetEndWithActions = 25;
+			
+			// aapt resource value: 22
+			public const int ActionBar_contentInsetLeft = 22;
+			
+			// aapt resource value: 23
+			public const int ActionBar_contentInsetRight = 23;
+			
+			// aapt resource value: 20
+			public const int ActionBar_contentInsetStart = 20;
+			
+			// aapt resource value: 24
+			public const int ActionBar_contentInsetStartWithNavigation = 24;
+			
+			// aapt resource value: 13
+			public const int ActionBar_customNavigationLayout = 13;
+			
+			// aapt resource value: 3
+			public const int ActionBar_displayOptions = 3;
+			
+			// aapt resource value: 9
+			public const int ActionBar_divider = 9;
+			
+			// aapt resource value: 26
+			public const int ActionBar_elevation = 26;
+			
+			// aapt resource value: 0
+			public const int ActionBar_height = 0;
+			
+			// aapt resource value: 19
+			public const int ActionBar_hideOnContentScroll = 19;
+			
+			// aapt resource value: 28
+			public const int ActionBar_homeAsUpIndicator = 28;
+			
+			// aapt resource value: 14
+			public const int ActionBar_homeLayout = 14;
+			
+			// aapt resource value: 7
+			public const int ActionBar_icon = 7;
+			
+			// aapt resource value: 16
+			public const int ActionBar_indeterminateProgressStyle = 16;
+			
+			// aapt resource value: 18
+			public const int ActionBar_itemPadding = 18;
+			
+			// aapt resource value: 8
+			public const int ActionBar_logo = 8;
+			
+			// aapt resource value: 2
+			public const int ActionBar_navigationMode = 2;
+			
+			// aapt resource value: 27
+			public const int ActionBar_popupTheme = 27;
+			
+			// aapt resource value: 17
+			public const int ActionBar_progressBarPadding = 17;
+			
+			// aapt resource value: 15
+			public const int ActionBar_progressBarStyle = 15;
+			
+			// aapt resource value: 4
+			public const int ActionBar_subtitle = 4;
+			
+			// aapt resource value: 6
+			public const int ActionBar_subtitleTextStyle = 6;
+			
+			// aapt resource value: 1
+			public const int ActionBar_title = 1;
+			
+			// aapt resource value: 5
+			public const int ActionBar_titleTextStyle = 5;
+			
+			public static int[] ActionBarLayout = new int[] {
+					16842931};
+			
+			// aapt resource value: 0
+			public const int ActionBarLayout_android_layout_gravity = 0;
+			
+			public static int[] ActionMenuItemView = new int[] {
+					16843071};
+			
+			// aapt resource value: 0
+			public const int ActionMenuItemView_android_minWidth = 0;
+			
+			public static int[] ActionMenuView;
+			
+			public static int[] ActionMode = new int[] {
+					2130771998,
+					2130772004,
+					2130772005,
+					2130772009,
+					2130772011,
+					2130772027};
+			
+			// aapt resource value: 3
+			public const int ActionMode_background = 3;
+			
+			// aapt resource value: 4
+			public const int ActionMode_backgroundSplit = 4;
+			
+			// aapt resource value: 5
+			public const int ActionMode_closeItemLayout = 5;
+			
+			// aapt resource value: 0
+			public const int ActionMode_height = 0;
+			
+			// aapt resource value: 2
+			public const int ActionMode_subtitleTextStyle = 2;
+			
+			// aapt resource value: 1
+			public const int ActionMode_titleTextStyle = 1;
+			
+			public static int[] ActivityChooserView = new int[] {
+					2130772028,
+					2130772029};
+			
+			// aapt resource value: 1
+			public const int ActivityChooserView_expandActivityOverflowButtonDrawable = 1;
+			
+			// aapt resource value: 0
+			public const int ActivityChooserView_initialActivityCount = 0;
+			
+			public static int[] AlertDialog = new int[] {
+					16842994,
+					2130772030,
+					2130772031,
+					2130772032,
+					2130772033,
+					2130772034};
+			
+			// aapt resource value: 0
+			public const int AlertDialog_android_layout = 0;
+			
+			// aapt resource value: 1
+			public const int AlertDialog_buttonPanelSideLayout = 1;
+			
+			// aapt resource value: 5
+			public const int AlertDialog_listItemLayout = 5;
+			
+			// aapt resource value: 2
+			public const int AlertDialog_listLayout = 2;
+			
+			// aapt resource value: 3
+			public const int AlertDialog_multiChoiceItemLayout = 3;
+			
+			// aapt resource value: 4
+			public const int AlertDialog_singleChoiceItemLayout = 4;
+			
+			public static int[] AppCompatImageView = new int[] {
+					16843033,
+					2130772035};
+			
+			// aapt resource value: 0
+			public const int AppCompatImageView_android_src = 0;
+			
+			// aapt resource value: 1
+			public const int AppCompatImageView_srcCompat = 1;
+			
+			public static int[] AppCompatSeekBar = new int[] {
+					16843074,
+					2130772036,
+					2130772037,
+					2130772038};
+			
+			// aapt resource value: 0
+			public const int AppCompatSeekBar_android_thumb = 0;
+			
+			// aapt resource value: 1
+			public const int AppCompatSeekBar_tickMark = 1;
+			
+			// aapt resource value: 2
+			public const int AppCompatSeekBar_tickMarkTint = 2;
+			
+			// aapt resource value: 3
+			public const int AppCompatSeekBar_tickMarkTintMode = 3;
+			
+			public static int[] AppCompatTextHelper = new int[] {
+					16842804,
+					16843117,
+					16843118,
+					16843119,
+					16843120,
+					16843666,
+					16843667};
+			
+			// aapt resource value: 2
+			public const int AppCompatTextHelper_android_drawableBottom = 2;
+			
+			// aapt resource value: 6
+			public const int AppCompatTextHelper_android_drawableEnd = 6;
+			
+			// aapt resource value: 3
+			public const int AppCompatTextHelper_android_drawableLeft = 3;
+			
+			// aapt resource value: 4
+			public const int AppCompatTextHelper_android_drawableRight = 4;
+			
+			// aapt resource value: 5
+			public const int AppCompatTextHelper_android_drawableStart = 5;
+			
+			// aapt resource value: 1
+			public const int AppCompatTextHelper_android_drawableTop = 1;
+			
+			// aapt resource value: 0
+			public const int AppCompatTextHelper_android_textAppearance = 0;
+			
+			public static int[] AppCompatTextView = new int[] {
+					16842804,
+					2130772039};
+			
+			// aapt resource value: 0
+			public const int AppCompatTextView_android_textAppearance = 0;
+			
+			// aapt resource value: 1
+			public const int AppCompatTextView_textAllCaps = 1;
+			
+			public static int[] AppCompatTheme = new int[] {
+					16842839,
+					16842926,
+					2130772040,
+					2130772041,
+					2130772042,
+					2130772043,
+					2130772044,
+					2130772045,
+					2130772046,
+					2130772047,
+					2130772048,
+					2130772049,
+					2130772050,
+					2130772051,
+					2130772052,
+					2130772053,
+					2130772054,
+					2130772055,
+					2130772056,
+					2130772057,
+					2130772058,
+					2130772059,
+					2130772060,
+					2130772061,
+					2130772062,
+					2130772063,
+					2130772064,
+					2130772065,
+					2130772066,
+					2130772067,
+					2130772068,
+					2130772069,
+					2130772070,
+					2130772071,
+					2130772072,
+					2130772073,
+					2130772074,
+					2130772075,
+					2130772076,
+					2130772077,
+					2130772078,
+					2130772079,
+					2130772080,
+					2130772081,
+					2130772082,
+					2130772083,
+					2130772084,
+					2130772085,
+					2130772086,
+					2130772087,
+					2130772088,
+					2130772089,
+					2130772090,
+					2130772091,
+					2130772092,
+					2130772093,
+					2130772094,
+					2130772095,
+					2130772096,
+					2130772097,
+					2130772098,
+					2130772099,
+					2130772100,
+					2130772101,
+					2130772102,
+					2130772103,
+					2130772104,
+					2130772105,
+					2130772106,
+					2130772107,
+					2130772108,
+					2130772109,
+					2130772110,
+					2130772111,
+					2130772112,
+					2130772113,
+					2130772114,
+					2130772115,
+					2130772116,
+					2130772117,
+					2130772118,
+					2130772119,
+					2130772120,
+					2130772121,
+					2130772122,
+					2130772123,
+					2130772124,
+					2130772125,
+					2130772126,
+					2130772127,
+					2130772128,
+					2130772129,
+					2130772130,
+					2130772131,
+					2130772132,
+					2130772133,
+					2130772134,
+					2130772135,
+					2130772136,
+					2130772137,
+					2130772138,
+					2130772139,
+					2130772140,
+					2130772141,
+					2130772142,
+					2130772143,
+					2130772144,
+					2130772145,
+					2130772146,
+					2130772147,
+					2130772148,
+					2130772149,
+					2130772150,
+					2130772151,
+					2130772152};
+			
+			// aapt resource value: 23
+			public const int AppCompatTheme_actionBarDivider = 23;
+			
+			// aapt resource value: 24
+			public const int AppCompatTheme_actionBarItemBackground = 24;
+			
+			// aapt resource value: 17
+			public const int AppCompatTheme_actionBarPopupTheme = 17;
+			
+			// aapt resource value: 22
+			public const int AppCompatTheme_actionBarSize = 22;
+			
+			// aapt resource value: 19
+			public const int AppCompatTheme_actionBarSplitStyle = 19;
+			
+			// aapt resource value: 18
+			public const int AppCompatTheme_actionBarStyle = 18;
+			
+			// aapt resource value: 13
+			public const int AppCompatTheme_actionBarTabBarStyle = 13;
+			
+			// aapt resource value: 12
+			public const int AppCompatTheme_actionBarTabStyle = 12;
+			
+			// aapt resource value: 14
+			public const int AppCompatTheme_actionBarTabTextStyle = 14;
+			
+			// aapt resource value: 20
+			public const int AppCompatTheme_actionBarTheme = 20;
+			
+			// aapt resource value: 21
+			public const int AppCompatTheme_actionBarWidgetTheme = 21;
+			
+			// aapt resource value: 50
+			public const int AppCompatTheme_actionButtonStyle = 50;
+			
+			// aapt resource value: 46
+			public const int AppCompatTheme_actionDropDownStyle = 46;
+			
+			// aapt resource value: 25
+			public const int AppCompatTheme_actionMenuTextAppearance = 25;
+			
+			// aapt resource value: 26
+			public const int AppCompatTheme_actionMenuTextColor = 26;
+			
+			// aapt resource value: 29
+			public const int AppCompatTheme_actionModeBackground = 29;
+			
+			// aapt resource value: 28
+			public const int AppCompatTheme_actionModeCloseButtonStyle = 28;
+			
+			// aapt resource value: 31
+			public const int AppCompatTheme_actionModeCloseDrawable = 31;
+			
+			// aapt resource value: 33
+			public const int AppCompatTheme_actionModeCopyDrawable = 33;
+			
+			// aapt resource value: 32
+			public const int AppCompatTheme_actionModeCutDrawable = 32;
+			
+			// aapt resource value: 37
+			public const int AppCompatTheme_actionModeFindDrawable = 37;
+			
+			// aapt resource value: 34
+			public const int AppCompatTheme_actionModePasteDrawable = 34;
+			
+			// aapt resource value: 39
+			public const int AppCompatTheme_actionModePopupWindowStyle = 39;
+			
+			// aapt resource value: 35
+			public const int AppCompatTheme_actionModeSelectAllDrawable = 35;
+			
+			// aapt resource value: 36
+			public const int AppCompatTheme_actionModeShareDrawable = 36;
+			
+			// aapt resource value: 30
+			public const int AppCompatTheme_actionModeSplitBackground = 30;
+			
+			// aapt resource value: 27
+			public const int AppCompatTheme_actionModeStyle = 27;
+			
+			// aapt resource value: 38
+			public const int AppCompatTheme_actionModeWebSearchDrawable = 38;
+			
+			// aapt resource value: 15
+			public const int AppCompatTheme_actionOverflowButtonStyle = 15;
+			
+			// aapt resource value: 16
+			public const int AppCompatTheme_actionOverflowMenuStyle = 16;
+			
+			// aapt resource value: 58
+			public const int AppCompatTheme_activityChooserViewStyle = 58;
+			
+			// aapt resource value: 94
+			public const int AppCompatTheme_alertDialogButtonGroupStyle = 94;
+			
+			// aapt resource value: 95
+			public const int AppCompatTheme_alertDialogCenterButtons = 95;
+			
+			// aapt resource value: 93
+			public const int AppCompatTheme_alertDialogStyle = 93;
+			
+			// aapt resource value: 96
+			public const int AppCompatTheme_alertDialogTheme = 96;
+			
+			// aapt resource value: 1
+			public const int AppCompatTheme_android_windowAnimationStyle = 1;
+			
+			// aapt resource value: 0
+			public const int AppCompatTheme_android_windowIsFloating = 0;
+			
+			// aapt resource value: 101
+			public const int AppCompatTheme_autoCompleteTextViewStyle = 101;
+			
+			// aapt resource value: 55
+			public const int AppCompatTheme_borderlessButtonStyle = 55;
+			
+			// aapt resource value: 52
+			public const int AppCompatTheme_buttonBarButtonStyle = 52;
+			
+			// aapt resource value: 99
+			public const int AppCompatTheme_buttonBarNegativeButtonStyle = 99;
+			
+			// aapt resource value: 100
+			public const int AppCompatTheme_buttonBarNeutralButtonStyle = 100;
+			
+			// aapt resource value: 98
+			public const int AppCompatTheme_buttonBarPositiveButtonStyle = 98;
+			
+			// aapt resource value: 51
+			public const int AppCompatTheme_buttonBarStyle = 51;
+			
+			// aapt resource value: 102
+			public const int AppCompatTheme_buttonStyle = 102;
+			
+			// aapt resource value: 103
+			public const int AppCompatTheme_buttonStyleSmall = 103;
+			
+			// aapt resource value: 104
+			public const int AppCompatTheme_checkboxStyle = 104;
+			
+			// aapt resource value: 105
+			public const int AppCompatTheme_checkedTextViewStyle = 105;
+			
+			// aapt resource value: 85
+			public const int AppCompatTheme_colorAccent = 85;
+			
+			// aapt resource value: 92
+			public const int AppCompatTheme_colorBackgroundFloating = 92;
+			
+			// aapt resource value: 89
+			public const int AppCompatTheme_colorButtonNormal = 89;
+			
+			// aapt resource value: 87
+			public const int AppCompatTheme_colorControlActivated = 87;
+			
+			// aapt resource value: 88
+			public const int AppCompatTheme_colorControlHighlight = 88;
+			
+			// aapt resource value: 86
+			public const int AppCompatTheme_colorControlNormal = 86;
+			
+			// aapt resource value: 83
+			public const int AppCompatTheme_colorPrimary = 83;
+			
+			// aapt resource value: 84
+			public const int AppCompatTheme_colorPrimaryDark = 84;
+			
+			// aapt resource value: 90
+			public const int AppCompatTheme_colorSwitchThumbNormal = 90;
+			
+			// aapt resource value: 91
+			public const int AppCompatTheme_controlBackground = 91;
+			
+			// aapt resource value: 44
+			public const int AppCompatTheme_dialogPreferredPadding = 44;
+			
+			// aapt resource value: 43
+			public const int AppCompatTheme_dialogTheme = 43;
+			
+			// aapt resource value: 57
+			public const int AppCompatTheme_dividerHorizontal = 57;
+			
+			// aapt resource value: 56
+			public const int AppCompatTheme_dividerVertical = 56;
+			
+			// aapt resource value: 75
+			public const int AppCompatTheme_dropDownListViewStyle = 75;
+			
+			// aapt resource value: 47
+			public const int AppCompatTheme_dropdownListPreferredItemHeight = 47;
+			
+			// aapt resource value: 64
+			public const int AppCompatTheme_editTextBackground = 64;
+			
+			// aapt resource value: 63
+			public const int AppCompatTheme_editTextColor = 63;
+			
+			// aapt resource value: 106
+			public const int AppCompatTheme_editTextStyle = 106;
+			
+			// aapt resource value: 49
+			public const int AppCompatTheme_homeAsUpIndicator = 49;
+			
+			// aapt resource value: 65
+			public const int AppCompatTheme_imageButtonStyle = 65;
+			
+			// aapt resource value: 82
+			public const int AppCompatTheme_listChoiceBackgroundIndicator = 82;
+			
+			// aapt resource value: 45
+			public const int AppCompatTheme_listDividerAlertDialog = 45;
+			
+			// aapt resource value: 114
+			public const int AppCompatTheme_listMenuViewStyle = 114;
+			
+			// aapt resource value: 76
+			public const int AppCompatTheme_listPopupWindowStyle = 76;
+			
+			// aapt resource value: 70
+			public const int AppCompatTheme_listPreferredItemHeight = 70;
+			
+			// aapt resource value: 72
+			public const int AppCompatTheme_listPreferredItemHeightLarge = 72;
+			
+			// aapt resource value: 71
+			public const int AppCompatTheme_listPreferredItemHeightSmall = 71;
+			
+			// aapt resource value: 73
+			public const int AppCompatTheme_listPreferredItemPaddingLeft = 73;
+			
+			// aapt resource value: 74
+			public const int AppCompatTheme_listPreferredItemPaddingRight = 74;
+			
+			// aapt resource value: 79
+			public const int AppCompatTheme_panelBackground = 79;
+			
+			// aapt resource value: 81
+			public const int AppCompatTheme_panelMenuListTheme = 81;
+			
+			// aapt resource value: 80
+			public const int AppCompatTheme_panelMenuListWidth = 80;
+			
+			// aapt resource value: 61
+			public const int AppCompatTheme_popupMenuStyle = 61;
+			
+			// aapt resource value: 62
+			public const int AppCompatTheme_popupWindowStyle = 62;
+			
+			// aapt resource value: 107
+			public const int AppCompatTheme_radioButtonStyle = 107;
+			
+			// aapt resource value: 108
+			public const int AppCompatTheme_ratingBarStyle = 108;
+			
+			// aapt resource value: 109
+			public const int AppCompatTheme_ratingBarStyleIndicator = 109;
+			
+			// aapt resource value: 110
+			public const int AppCompatTheme_ratingBarStyleSmall = 110;
+			
+			// aapt resource value: 69
+			public const int AppCompatTheme_searchViewStyle = 69;
+			
+			// aapt resource value: 111
+			public const int AppCompatTheme_seekBarStyle = 111;
+			
+			// aapt resource value: 53
+			public const int AppCompatTheme_selectableItemBackground = 53;
+			
+			// aapt resource value: 54
+			public const int AppCompatTheme_selectableItemBackgroundBorderless = 54;
+			
+			// aapt resource value: 48
+			public const int AppCompatTheme_spinnerDropDownItemStyle = 48;
+			
+			// aapt resource value: 112
+			public const int AppCompatTheme_spinnerStyle = 112;
+			
+			// aapt resource value: 113
+			public const int AppCompatTheme_switchStyle = 113;
+			
+			// aapt resource value: 40
+			public const int AppCompatTheme_textAppearanceLargePopupMenu = 40;
+			
+			// aapt resource value: 77
+			public const int AppCompatTheme_textAppearanceListItem = 77;
+			
+			// aapt resource value: 78
+			public const int AppCompatTheme_textAppearanceListItemSmall = 78;
+			
+			// aapt resource value: 42
+			public const int AppCompatTheme_textAppearancePopupMenuHeader = 42;
+			
+			// aapt resource value: 67
+			public const int AppCompatTheme_textAppearanceSearchResultSubtitle = 67;
+			
+			// aapt resource value: 66
+			public const int AppCompatTheme_textAppearanceSearchResultTitle = 66;
+			
+			// aapt resource value: 41
+			public const int AppCompatTheme_textAppearanceSmallPopupMenu = 41;
+			
+			// aapt resource value: 97
+			public const int AppCompatTheme_textColorAlertDialogListItem = 97;
+			
+			// aapt resource value: 68
+			public const int AppCompatTheme_textColorSearchUrl = 68;
+			
+			// aapt resource value: 60
+			public const int AppCompatTheme_toolbarNavigationButtonStyle = 60;
+			
+			// aapt resource value: 59
+			public const int AppCompatTheme_toolbarStyle = 59;
+			
+			// aapt resource value: 2
+			public const int AppCompatTheme_windowActionBar = 2;
+			
+			// aapt resource value: 4
+			public const int AppCompatTheme_windowActionBarOverlay = 4;
+			
+			// aapt resource value: 5
+			public const int AppCompatTheme_windowActionModeOverlay = 5;
+			
+			// aapt resource value: 9
+			public const int AppCompatTheme_windowFixedHeightMajor = 9;
+			
+			// aapt resource value: 7
+			public const int AppCompatTheme_windowFixedHeightMinor = 7;
+			
+			// aapt resource value: 6
+			public const int AppCompatTheme_windowFixedWidthMajor = 6;
+			
+			// aapt resource value: 8
+			public const int AppCompatTheme_windowFixedWidthMinor = 8;
+			
+			// aapt resource value: 10
+			public const int AppCompatTheme_windowMinWidthMajor = 10;
+			
+			// aapt resource value: 11
+			public const int AppCompatTheme_windowMinWidthMinor = 11;
+			
+			// aapt resource value: 3
+			public const int AppCompatTheme_windowNoTitle = 3;
+			
+			public static int[] ButtonBarLayout = new int[] {
+					2130772153};
+			
+			// aapt resource value: 0
+			public const int ButtonBarLayout_allowStacking = 0;
+			
+			public static int[] ColorStateListItem = new int[] {
+					16843173,
+					16843551,
+					2130772154};
+			
+			// aapt resource value: 2
+			public const int ColorStateListItem_alpha = 2;
+			
+			// aapt resource value: 1
+			public const int ColorStateListItem_android_alpha = 1;
+			
+			// aapt resource value: 0
+			public const int ColorStateListItem_android_color = 0;
+			
+			public static int[] CompoundButton = new int[] {
+					16843015,
+					2130772155,
+					2130772156};
+			
+			// aapt resource value: 0
+			public const int CompoundButton_android_button = 0;
+			
+			// aapt resource value: 1
+			public const int CompoundButton_buttonTint = 1;
+			
+			// aapt resource value: 2
+			public const int CompoundButton_buttonTintMode = 2;
+			
+			public static int[] DrawerArrowToggle = new int[] {
+					2130772157,
+					2130772158,
+					2130772159,
+					2130772160,
+					2130772161,
+					2130772162,
+					2130772163,
+					2130772164};
+			
+			// aapt resource value: 4
+			public const int DrawerArrowToggle_arrowHeadLength = 4;
+			
+			// aapt resource value: 5
+			public const int DrawerArrowToggle_arrowShaftLength = 5;
+			
+			// aapt resource value: 6
+			public const int DrawerArrowToggle_barLength = 6;
+			
+			// aapt resource value: 0
+			public const int DrawerArrowToggle_color = 0;
+			
+			// aapt resource value: 2
+			public const int DrawerArrowToggle_drawableSize = 2;
+			
+			// aapt resource value: 3
+			public const int DrawerArrowToggle_gapBetweenBars = 3;
+			
+			// aapt resource value: 1
+			public const int DrawerArrowToggle_spinBars = 1;
+			
+			// aapt resource value: 7
+			public const int DrawerArrowToggle_thickness = 7;
+			
+			public static int[] LinearLayoutCompat = new int[] {
+					16842927,
+					16842948,
+					16843046,
+					16843047,
+					16843048,
+					2130772008,
+					2130772165,
+					2130772166,
+					2130772167};
+			
+			// aapt resource value: 2
+			public const int LinearLayoutCompat_android_baselineAligned = 2;
+			
+			// aapt resource value: 3
+			public const int LinearLayoutCompat_android_baselineAlignedChildIndex = 3;
+			
+			// aapt resource value: 0
+			public const int LinearLayoutCompat_android_gravity = 0;
+			
+			// aapt resource value: 1
+			public const int LinearLayoutCompat_android_orientation = 1;
+			
+			// aapt resource value: 4
+			public const int LinearLayoutCompat_android_weightSum = 4;
+			
+			// aapt resource value: 5
+			public const int LinearLayoutCompat_divider = 5;
+			
+			// aapt resource value: 8
+			public const int LinearLayoutCompat_dividerPadding = 8;
+			
+			// aapt resource value: 6
+			public const int LinearLayoutCompat_measureWithLargestChild = 6;
+			
+			// aapt resource value: 7
+			public const int LinearLayoutCompat_showDividers = 7;
+			
+			public static int[] LinearLayoutCompat_Layout = new int[] {
+					16842931,
+					16842996,
+					16842997,
+					16843137};
+			
+			// aapt resource value: 0
+			public const int LinearLayoutCompat_Layout_android_layout_gravity = 0;
+			
+			// aapt resource value: 2
+			public const int LinearLayoutCompat_Layout_android_layout_height = 2;
+			
+			// aapt resource value: 3
+			public const int LinearLayoutCompat_Layout_android_layout_weight = 3;
+			
+			// aapt resource value: 1
+			public const int LinearLayoutCompat_Layout_android_layout_width = 1;
+			
+			public static int[] ListPopupWindow = new int[] {
+					16843436,
+					16843437};
+			
+			// aapt resource value: 0
+			public const int ListPopupWindow_android_dropDownHorizontalOffset = 0;
+			
+			// aapt resource value: 1
+			public const int ListPopupWindow_android_dropDownVerticalOffset = 1;
+			
+			public static int[] LoadingImageView = new int[] {
+					2130771968,
+					2130771969,
+					2130771970};
+			
+			// aapt resource value: 2
+			public const int LoadingImageView_circleCrop = 2;
+			
+			// aapt resource value: 1
+			public const int LoadingImageView_imageAspectRatio = 1;
+			
+			// aapt resource value: 0
+			public const int LoadingImageView_imageAspectRatioAdjust = 0;
+			
+			public static int[] MapAttrs = new int[] {
+					2130771974,
+					2130771975,
+					2130771976,
+					2130771977,
+					2130771978,
+					2130771979,
+					2130771980,
+					2130771981,
+					2130771982,
+					2130771983,
+					2130771984,
+					2130771985,
+					2130771986,
+					2130771987,
+					2130771988,
+					2130771989,
+					2130771990,
+					2130771991,
+					2130771992,
+					2130771993,
+					2130771994,
+					2130771995,
+					2130771996};
+			
+			// aapt resource value: 16
+			public const int MapAttrs_ambientEnabled = 16;
+			
+			// aapt resource value: 1
+			public const int MapAttrs_cameraBearing = 1;
+			
+			// aapt resource value: 18
+			public const int MapAttrs_cameraMaxZoomPreference = 18;
+			
+			// aapt resource value: 17
+			public const int MapAttrs_cameraMinZoomPreference = 17;
+			
+			// aapt resource value: 2
+			public const int MapAttrs_cameraTargetLat = 2;
+			
+			// aapt resource value: 3
+			public const int MapAttrs_cameraTargetLng = 3;
+			
+			// aapt resource value: 4
+			public const int MapAttrs_cameraTilt = 4;
+			
+			// aapt resource value: 5
+			public const int MapAttrs_cameraZoom = 5;
+			
+			// aapt resource value: 21
+			public const int MapAttrs_latLngBoundsNorthEastLatitude = 21;
+			
+			// aapt resource value: 22
+			public const int MapAttrs_latLngBoundsNorthEastLongitude = 22;
+			
+			// aapt resource value: 19
+			public const int MapAttrs_latLngBoundsSouthWestLatitude = 19;
+			
+			// aapt resource value: 20
+			public const int MapAttrs_latLngBoundsSouthWestLongitude = 20;
+			
+			// aapt resource value: 6
+			public const int MapAttrs_liteMode = 6;
+			
+			// aapt resource value: 0
+			public const int MapAttrs_mapType = 0;
+			
+			// aapt resource value: 7
+			public const int MapAttrs_uiCompass = 7;
+			
+			// aapt resource value: 15
+			public const int MapAttrs_uiMapToolbar = 15;
+			
+			// aapt resource value: 8
+			public const int MapAttrs_uiRotateGestures = 8;
+			
+			// aapt resource value: 9
+			public const int MapAttrs_uiScrollGestures = 9;
+			
+			// aapt resource value: 10
+			public const int MapAttrs_uiTiltGestures = 10;
+			
+			// aapt resource value: 11
+			public const int MapAttrs_uiZoomControls = 11;
+			
+			// aapt resource value: 12
+			public const int MapAttrs_uiZoomGestures = 12;
+			
+			// aapt resource value: 13
+			public const int MapAttrs_useViewLifecycle = 13;
+			
+			// aapt resource value: 14
+			public const int MapAttrs_zOrderOnTop = 14;
+			
+			public static int[] MenuGroup = new int[] {
+					16842766,
+					16842960,
+					16843156,
+					16843230,
+					16843231,
+					16843232};
+			
+			// aapt resource value: 5
+			public const int MenuGroup_android_checkableBehavior = 5;
+			
+			// aapt resource value: 0
+			public const int MenuGroup_android_enabled = 0;
+			
+			// aapt resource value: 1
+			public const int MenuGroup_android_id = 1;
+			
+			// aapt resource value: 3
+			public const int MenuGroup_android_menuCategory = 3;
+			
+			// aapt resource value: 4
+			public const int MenuGroup_android_orderInCategory = 4;
+			
+			// aapt resource value: 2
+			public const int MenuGroup_android_visible = 2;
+			
+			public static int[] MenuItem = new int[] {
+					16842754,
+					16842766,
+					16842960,
+					16843014,
+					16843156,
+					16843230,
+					16843231,
+					16843233,
+					16843234,
+					16843235,
+					16843236,
+					16843237,
+					16843375,
+					2130772168,
+					2130772169,
+					2130772170,
+					2130772171};
+			
+			// aapt resource value: 14
+			public const int MenuItem_actionLayout = 14;
+			
+			// aapt resource value: 16
+			public const int MenuItem_actionProviderClass = 16;
+			
+			// aapt resource value: 15
+			public const int MenuItem_actionViewClass = 15;
+			
+			// aapt resource value: 9
+			public const int MenuItem_android_alphabeticShortcut = 9;
+			
+			// aapt resource value: 11
+			public const int MenuItem_android_checkable = 11;
+			
+			// aapt resource value: 3
+			public const int MenuItem_android_checked = 3;
+			
+			// aapt resource value: 1
+			public const int MenuItem_android_enabled = 1;
+			
+			// aapt resource value: 0
+			public const int MenuItem_android_icon = 0;
+			
+			// aapt resource value: 2
+			public const int MenuItem_android_id = 2;
+			
+			// aapt resource value: 5
+			public const int MenuItem_android_menuCategory = 5;
+			
+			// aapt resource value: 10
+			public const int MenuItem_android_numericShortcut = 10;
+			
+			// aapt resource value: 12
+			public const int MenuItem_android_onClick = 12;
+			
+			// aapt resource value: 6
+			public const int MenuItem_android_orderInCategory = 6;
+			
+			// aapt resource value: 7
+			public const int MenuItem_android_title = 7;
+			
+			// aapt resource value: 8
+			public const int MenuItem_android_titleCondensed = 8;
+			
+			// aapt resource value: 4
+			public const int MenuItem_android_visible = 4;
+			
+			// aapt resource value: 13
+			public const int MenuItem_showAsAction = 13;
+			
+			public static int[] MenuView = new int[] {
+					16842926,
+					16843052,
+					16843053,
+					16843054,
+					16843055,
+					16843056,
+					16843057,
+					2130772172,
+					2130772173};
+			
+			// aapt resource value: 4
+			public const int MenuView_android_headerBackground = 4;
+			
+			// aapt resource value: 2
+			public const int MenuView_android_horizontalDivider = 2;
+			
+			// aapt resource value: 5
+			public const int MenuView_android_itemBackground = 5;
+			
+			// aapt resource value: 6
+			public const int MenuView_android_itemIconDisabledAlpha = 6;
+			
+			// aapt resource value: 1
+			public const int MenuView_android_itemTextAppearance = 1;
+			
+			// aapt resource value: 3
+			public const int MenuView_android_verticalDivider = 3;
+			
+			// aapt resource value: 0
+			public const int MenuView_android_windowAnimationStyle = 0;
+			
+			// aapt resource value: 7
+			public const int MenuView_preserveIconSpacing = 7;
+			
+			// aapt resource value: 8
+			public const int MenuView_subMenuArrow = 8;
+			
+			public static int[] PopupWindow = new int[] {
+					16843126,
+					16843465,
+					2130772174};
+			
+			// aapt resource value: 1
+			public const int PopupWindow_android_popupAnimationStyle = 1;
+			
+			// aapt resource value: 0
+			public const int PopupWindow_android_popupBackground = 0;
+			
+			// aapt resource value: 2
+			public const int PopupWindow_overlapAnchor = 2;
+			
+			public static int[] PopupWindowBackgroundState = new int[] {
+					2130772175};
+			
+			// aapt resource value: 0
+			public const int PopupWindowBackgroundState_state_above_anchor = 0;
+			
+			public static int[] SearchView = new int[] {
+					16842970,
+					16843039,
+					16843296,
+					16843364,
+					2130772176,
+					2130772177,
+					2130772178,
+					2130772179,
+					2130772180,
+					2130772181,
+					2130772182,
+					2130772183,
+					2130772184,
+					2130772185,
+					2130772186,
+					2130772187,
+					2130772188};
+			
+			// aapt resource value: 0
+			public const int SearchView_android_focusable = 0;
+			
+			// aapt resource value: 3
+			public const int SearchView_android_imeOptions = 3;
+			
+			// aapt resource value: 2
+			public const int SearchView_android_inputType = 2;
+			
+			// aapt resource value: 1
+			public const int SearchView_android_maxWidth = 1;
+			
+			// aapt resource value: 8
+			public const int SearchView_closeIcon = 8;
+			
+			// aapt resource value: 13
+			public const int SearchView_commitIcon = 13;
+			
+			// aapt resource value: 7
+			public const int SearchView_defaultQueryHint = 7;
+			
+			// aapt resource value: 9
+			public const int SearchView_goIcon = 9;
+			
+			// aapt resource value: 5
+			public const int SearchView_iconifiedByDefault = 5;
+			
+			// aapt resource value: 4
+			public const int SearchView_layout = 4;
+			
+			// aapt resource value: 15
+			public const int SearchView_queryBackground = 15;
+			
+			// aapt resource value: 6
+			public const int SearchView_queryHint = 6;
+			
+			// aapt resource value: 11
+			public const int SearchView_searchHintIcon = 11;
+			
+			// aapt resource value: 10
+			public const int SearchView_searchIcon = 10;
+			
+			// aapt resource value: 16
+			public const int SearchView_submitBackground = 16;
+			
+			// aapt resource value: 14
+			public const int SearchView_suggestionRowLayout = 14;
+			
+			// aapt resource value: 12
+			public const int SearchView_voiceIcon = 12;
+			
+			public static int[] SignInButton = new int[] {
+					2130771971,
+					2130771972,
+					2130771973};
+			
+			// aapt resource value: 0
+			public const int SignInButton_buttonSize = 0;
+			
+			// aapt resource value: 1
+			public const int SignInButton_colorScheme = 1;
+			
+			// aapt resource value: 2
+			public const int SignInButton_scopeUris = 2;
+			
+			public static int[] Spinner = new int[] {
+					16842930,
+					16843126,
+					16843131,
+					16843362,
+					2130772026};
+			
+			// aapt resource value: 3
+			public const int Spinner_android_dropDownWidth = 3;
+			
+			// aapt resource value: 0
+			public const int Spinner_android_entries = 0;
+			
+			// aapt resource value: 1
+			public const int Spinner_android_popupBackground = 1;
+			
+			// aapt resource value: 2
+			public const int Spinner_android_prompt = 2;
+			
+			// aapt resource value: 4
+			public const int Spinner_popupTheme = 4;
+			
+			public static int[] SwitchCompat = new int[] {
+					16843044,
+					16843045,
+					16843074,
+					2130772189,
+					2130772190,
+					2130772191,
+					2130772192,
+					2130772193,
+					2130772194,
+					2130772195,
+					2130772196,
+					2130772197,
+					2130772198,
+					2130772199};
+			
+			// aapt resource value: 1
+			public const int SwitchCompat_android_textOff = 1;
+			
+			// aapt resource value: 0
+			public const int SwitchCompat_android_textOn = 0;
+			
+			// aapt resource value: 2
+			public const int SwitchCompat_android_thumb = 2;
+			
+			// aapt resource value: 13
+			public const int SwitchCompat_showText = 13;
+			
+			// aapt resource value: 12
+			public const int SwitchCompat_splitTrack = 12;
+			
+			// aapt resource value: 10
+			public const int SwitchCompat_switchMinWidth = 10;
+			
+			// aapt resource value: 11
+			public const int SwitchCompat_switchPadding = 11;
+			
+			// aapt resource value: 9
+			public const int SwitchCompat_switchTextAppearance = 9;
+			
+			// aapt resource value: 8
+			public const int SwitchCompat_thumbTextPadding = 8;
+			
+			// aapt resource value: 3
+			public const int SwitchCompat_thumbTint = 3;
+			
+			// aapt resource value: 4
+			public const int SwitchCompat_thumbTintMode = 4;
+			
+			// aapt resource value: 5
+			public const int SwitchCompat_track = 5;
+			
+			// aapt resource value: 6
+			public const int SwitchCompat_trackTint = 6;
+			
+			// aapt resource value: 7
+			public const int SwitchCompat_trackTintMode = 7;
+			
+			public static int[] TextAppearance = new int[] {
+					16842901,
+					16842902,
+					16842903,
+					16842904,
+					16843105,
+					16843106,
+					16843107,
+					16843108,
+					2130772039};
+			
+			// aapt resource value: 4
+			public const int TextAppearance_android_shadowColor = 4;
+			
+			// aapt resource value: 5
+			public const int TextAppearance_android_shadowDx = 5;
+			
+			// aapt resource value: 6
+			public const int TextAppearance_android_shadowDy = 6;
+			
+			// aapt resource value: 7
+			public const int TextAppearance_android_shadowRadius = 7;
+			
+			// aapt resource value: 3
+			public const int TextAppearance_android_textColor = 3;
+			
+			// aapt resource value: 0
+			public const int TextAppearance_android_textSize = 0;
+			
+			// aapt resource value: 2
+			public const int TextAppearance_android_textStyle = 2;
+			
+			// aapt resource value: 1
+			public const int TextAppearance_android_typeface = 1;
+			
+			// aapt resource value: 8
+			public const int TextAppearance_textAllCaps = 8;
+			
+			public static int[] Toolbar = new int[] {
+					16842927,
+					16843072,
+					2130772000,
+					2130772003,
+					2130772007,
+					2130772019,
+					2130772020,
+					2130772021,
+					2130772022,
+					2130772023,
+					2130772024,
+					2130772026,
+					2130772200,
+					2130772201,
+					2130772202,
+					2130772203,
+					2130772204,
+					2130772205,
+					2130772206,
+					2130772207,
+					2130772208,
+					2130772209,
+					2130772210,
+					2130772211,
+					2130772212,
+					2130772213,
+					2130772214,
+					2130772215,
+					2130772216};
+			
+			// aapt resource value: 0
+			public const int Toolbar_android_gravity = 0;
+			
+			// aapt resource value: 1
+			public const int Toolbar_android_minHeight = 1;
+			
+			// aapt resource value: 21
+			public const int Toolbar_buttonGravity = 21;
+			
+			// aapt resource value: 23
+			public const int Toolbar_collapseContentDescription = 23;
+			
+			// aapt resource value: 22
+			public const int Toolbar_collapseIcon = 22;
+			
+			// aapt resource value: 6
+			public const int Toolbar_contentInsetEnd = 6;
+			
+			// aapt resource value: 10
+			public const int Toolbar_contentInsetEndWithActions = 10;
+			
+			// aapt resource value: 7
+			public const int Toolbar_contentInsetLeft = 7;
+			
+			// aapt resource value: 8
+			public const int Toolbar_contentInsetRight = 8;
+			
+			// aapt resource value: 5
+			public const int Toolbar_contentInsetStart = 5;
+			
+			// aapt resource value: 9
+			public const int Toolbar_contentInsetStartWithNavigation = 9;
+			
+			// aapt resource value: 4
+			public const int Toolbar_logo = 4;
+			
+			// aapt resource value: 26
+			public const int Toolbar_logoDescription = 26;
+			
+			// aapt resource value: 20
+			public const int Toolbar_maxButtonHeight = 20;
+			
+			// aapt resource value: 25
+			public const int Toolbar_navigationContentDescription = 25;
+			
+			// aapt resource value: 24
+			public const int Toolbar_navigationIcon = 24;
+			
+			// aapt resource value: 11
+			public const int Toolbar_popupTheme = 11;
+			
+			// aapt resource value: 3
+			public const int Toolbar_subtitle = 3;
+			
+			// aapt resource value: 13
+			public const int Toolbar_subtitleTextAppearance = 13;
+			
+			// aapt resource value: 28
+			public const int Toolbar_subtitleTextColor = 28;
+			
+			// aapt resource value: 2
+			public const int Toolbar_title = 2;
+			
+			// aapt resource value: 14
+			public const int Toolbar_titleMargin = 14;
+			
+			// aapt resource value: 18
+			public const int Toolbar_titleMarginBottom = 18;
+			
+			// aapt resource value: 16
+			public const int Toolbar_titleMarginEnd = 16;
+			
+			// aapt resource value: 15
+			public const int Toolbar_titleMarginStart = 15;
+			
+			// aapt resource value: 17
+			public const int Toolbar_titleMarginTop = 17;
+			
+			// aapt resource value: 19
+			public const int Toolbar_titleMargins = 19;
+			
+			// aapt resource value: 12
+			public const int Toolbar_titleTextAppearance = 12;
+			
+			// aapt resource value: 27
+			public const int Toolbar_titleTextColor = 27;
+			
+			public static int[] View = new int[] {
+					16842752,
+					16842970,
+					2130772217,
+					2130772218,
+					2130772219};
+			
+			// aapt resource value: 1
+			public const int View_android_focusable = 1;
+			
+			// aapt resource value: 0
+			public const int View_android_theme = 0;
+			
+			// aapt resource value: 3
+			public const int View_paddingEnd = 3;
+			
+			// aapt resource value: 2
+			public const int View_paddingStart = 2;
+			
+			// aapt resource value: 4
+			public const int View_theme = 4;
+			
+			public static int[] ViewBackgroundHelper = new int[] {
+					16842964,
+					2130772220,
+					2130772221};
+			
+			// aapt resource value: 0
+			public const int ViewBackgroundHelper_android_background = 0;
+			
+			// aapt resource value: 1
+			public const int ViewBackgroundHelper_backgroundTint = 1;
+			
+			// aapt resource value: 2
+			public const int ViewBackgroundHelper_backgroundTintMode = 2;
+			
+			public static int[] ViewStubCompat = new int[] {
+					16842960,
+					16842994,
+					16842995};
+			
+			// aapt resource value: 0
+			public const int ViewStubCompat_android_id = 0;
+			
+			// aapt resource value: 2
+			public const int ViewStubCompat_android_inflatedId = 2;
+			
+			// aapt resource value: 1
+			public const int ViewStubCompat_android_layout = 1;
+			
+			static Styleable()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Styleable()
 			{
 			}
 		}

--- a/mRides-app/Activities/MatchActivity.cs
+++ b/mRides-app/Activities/MatchActivity.cs
@@ -115,7 +115,7 @@ namespace mRides_app
 
             // Capture the done button
             this.doneButton = FindViewById<Button>(Resource.Id.userMatchButtonDone);
-            this.doneButton.Click += delegate { this.Finish(); };
+            this.doneButton.Click += delegate { this.Done(); };
 
             // Capture the chat button
             this.chatButton = FindViewById<Button>(Resource.Id.userMatchingChatButton);
@@ -169,7 +169,7 @@ namespace mRides_app
             FindMatchAsyncTask findMatchTask = new FindMatchAsyncTask(this.userRequest, this);
             findMatchTask.Execute(); // Upon completion, the OnFindMatchComplete method is invoked.
         }
-        
+
         /// <summary>
         /// Updates the view of this activity with the information related to the current
         /// request defined by the attributes list of requests and by the current index of
@@ -239,32 +239,49 @@ namespace mRides_app
             // Send confirmation message to the server if driver accepted
             if(accept)
             {
-                if(this.userType == Request.TYPE_DRIVER)
+                Toast.MakeText(ApplicationContext, Resources.GetString(Resource.String.matchRequestSent), ToastLength.Short).Show();
+                if (this.userType == Request.TYPE_DRIVER)
                 {
                     consoleMapper.Confirm(this.matchedRequests[currentMatchedUserIndex].riderRequests.First().requestID, this.userRequest.ID);
+                    this.LoadNextMatchedRequest();
                 }
                 else
                 {
                     consoleMapper.Confirm(this.matchedRequests[currentMatchedUserIndex].ID, this.userRequest.ID);
+                    this.Done();
                 }
-                
-                Toast.MakeText(ApplicationContext, Resources.GetString(Resource.String.matchRequestSent), ToastLength.Short).Show();
             }
             else
             {
                 Toast.MakeText(ApplicationContext, Resources.GetString(Resource.String.matchDeclined), ToastLength.Short).Show();
-            }
+                this.LoadNextMatchedRequest();
+            }            
+        }
 
-            // Update to the view if there is a next one, otherwise finish this activity
+        /// <summary>
+        /// Update to the view if there is a next one, otherwise finish this activity
+        /// </summary>
+        private void LoadNextMatchedRequest()
+        {
             if (++this.currentMatchedUserIndex < this.matchedRequests.Count)
             {
-                RunOnUiThread(()=> this.UpdateDisplay());
+                RunOnUiThread(() => this.UpdateDisplay());
             }
             else
             {
                 Toast.MakeText(ApplicationContext, Resources.GetString(Resource.String.matchNoMoreMatch), ToastLength.Long).Show();
-                this.Finish();
+                this.Done();
             }
+        }
+
+        /// <summary>
+        /// Goes to the UserCancelRideActivity when the matching session is finished
+        /// </summary>
+        private void Done()
+        {
+            Intent intent = new Intent(this, typeof(UserCancelRideActivity));
+            this.StartActivity(intent);
+            this.Finish();
         }
 
         

--- a/mRides-app/Resources/Resource.Designer.cs
+++ b/mRides-app/Resources/Resource.Designer.cs
@@ -2261,103 +2261,100 @@ namespace mRides_app
 			public const int home = 2130837622;
 			
 			// aapt resource value: 0x7f020077
-			public const int house_menu = 2130837623;
+			public const int ic_stat_ic_notification = 2130837623;
 			
 			// aapt resource value: 0x7f020078
-			public const int ic_stat_ic_notification = 2130837624;
+			public const int Icon = 2130837624;
 			
 			// aapt resource value: 0x7f020079
-			public const int Icon = 2130837625;
+			public const int loyolaTest = 2130837625;
 			
 			// aapt resource value: 0x7f02007a
-			public const int loyolaTest = 2130837626;
+			public const int m_Rides_Logo = 2130837626;
 			
 			// aapt resource value: 0x7f02007b
-			public const int m_Rides_Logo = 2130837627;
+			public const int map = 2130837627;
 			
 			// aapt resource value: 0x7f02007c
-			public const int map = 2130837628;
+			public const int mcgill_test = 2130837628;
 			
 			// aapt resource value: 0x7f02007d
-			public const int mcgill_test = 2130837629;
+			public const int Menu_Chat = 2130837629;
 			
 			// aapt resource value: 0x7f02007e
-			public const int Menu_Chat = 2130837630;
+			public const int Menu_CreateRide = 2130837630;
 			
 			// aapt resource value: 0x7f02007f
-			public const int Menu_CreateRide = 2130837631;
+			public const int Menu_Logout = 2130837631;
 			
 			// aapt resource value: 0x7f020080
-			public const int Menu_Logout = 2130837632;
+			public const int Menu_MyProfile = 2130837632;
 			
 			// aapt resource value: 0x7f020081
-			public const int Menu_MyProfile = 2130837633;
+			public const int Menu_MyRides = 2130837633;
 			
 			// aapt resource value: 0x7f020082
-			public const int Menu_MyRides = 2130837634;
+			public const int Menu_Preferences = 2130837634;
 			
 			// aapt resource value: 0x7f020083
-			public const int Menu_Preferences = 2130837635;
+			public const int mrides_logo = 2130837635;
 			
 			// aapt resource value: 0x7f020084
-			public const int mrides_logo = 2130837636;
-			
-			// aapt resource value: 0x7f020085
-			public const int navigation_empty_icon = 2130837637;
-			
-			// aapt resource value: 0x7f020097
-			public const int notification_template_icon_bg = 2130837655;
-			
-			// aapt resource value: 0x7f020086
-			public const int passenger_icon = 2130837638;
-			
-			// aapt resource value: 0x7f020087
-			public const int places_ic_clear = 2130837639;
-			
-			// aapt resource value: 0x7f020088
-			public const int places_ic_search = 2130837640;
-			
-			// aapt resource value: 0x7f020089
-			public const int powered_by_google_dark = 2130837641;
-			
-			// aapt resource value: 0x7f02008a
-			public const int powered_by_google_light = 2130837642;
-			
-			// aapt resource value: 0x7f02008b
-			public const int red_button = 2130837643;
-			
-			// aapt resource value: 0x7f02008c
-			public const int red_logo = 2130837644;
-			
-			// aapt resource value: 0x7f02008d
-			public const int redRoundedBg = 2130837645;
-			
-			// aapt resource value: 0x7f02008e
-			public const int settings = 2130837646;
-			
-			// aapt resource value: 0x7f02008f
-			public const int smsicongray = 2130837647;
-			
-			// aapt resource value: 0x7f020090
-			public const int smsicongreen = 2130837648;
-			
-			// aapt resource value: 0x7f020091
-			public const int smsiconred = 2130837649;
-			
-			// aapt resource value: 0x7f020092
-			public const int splash = 2130837650;
-			
-			// aapt resource value: 0x7f020093
-			public const int top_border = 2130837651;
-			
-			// aapt resource value: 0x7f020094
-			public const int trashcanCancel = 2130837652;
-			
-			// aapt resource value: 0x7f020095
-			public const int user = 2130837653;
+			public const int navigation_empty_icon = 2130837636;
 			
 			// aapt resource value: 0x7f020096
-			public const int userIcon2 = 2130837654;
+			public const int notification_template_icon_bg = 2130837654;
+			
+			// aapt resource value: 0x7f020085
+			public const int passenger_icon = 2130837637;
+			
+			// aapt resource value: 0x7f020086
+			public const int places_ic_clear = 2130837638;
+			
+			// aapt resource value: 0x7f020087
+			public const int places_ic_search = 2130837639;
+			
+			// aapt resource value: 0x7f020088
+			public const int powered_by_google_dark = 2130837640;
+			
+			// aapt resource value: 0x7f020089
+			public const int powered_by_google_light = 2130837641;
+			
+			// aapt resource value: 0x7f02008a
+			public const int red_button = 2130837642;
+			
+			// aapt resource value: 0x7f02008b
+			public const int red_logo = 2130837643;
+			
+			// aapt resource value: 0x7f02008c
+			public const int redRoundedBg = 2130837644;
+			
+			// aapt resource value: 0x7f02008d
+			public const int settings = 2130837645;
+			
+			// aapt resource value: 0x7f02008e
+			public const int smsicongray = 2130837646;
+			
+			// aapt resource value: 0x7f02008f
+			public const int smsicongreen = 2130837647;
+			
+			// aapt resource value: 0x7f020090
+			public const int smsiconred = 2130837648;
+			
+			// aapt resource value: 0x7f020091
+			public const int splash = 2130837649;
+			
+			// aapt resource value: 0x7f020092
+			public const int top_border = 2130837650;
+			
+			// aapt resource value: 0x7f020093
+			public const int trashcanCancel = 2130837651;
+			
+			// aapt resource value: 0x7f020094
+			public const int user = 2130837652;
+			
+			// aapt resource value: 0x7f020095
+			public const int userIcon2 = 2130837653;
 			
 			static Drawable()
 			{
@@ -2372,17 +2369,17 @@ namespace mRides_app
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f0900ae
-			public const int CancelRides_Checkbox = 2131296430;
+			// aapt resource value: 0x7f09009e
+			public const int CancelRides_Checkbox = 2131296414;
 			
-			// aapt resource value: 0x7f0900ad
-			public const int CancelRides_location = 2131296429;
+			// aapt resource value: 0x7f09009d
+			public const int CancelRides_location = 2131296413;
 			
-			// aapt resource value: 0x7f0900ac
-			public const int CancelRides_nameRider = 2131296428;
+			// aapt resource value: 0x7f09009c
+			public const int CancelRides_nameRider = 2131296412;
 			
-			// aapt resource value: 0x7f09012f
-			public const int CloseButton = 2131296559;
+			// aapt resource value: 0x7f090123
+			public const int CloseButton = 2131296547;
 			
 			// aapt resource value: 0x7f09007d
 			public const int Image = 2131296381;
@@ -2390,14 +2387,14 @@ namespace mRides_app
 			// aapt resource value: 0x7f090081
 			public const int List = 2131296385;
 			
-			// aapt resource value: 0x7f090130
-			public const int Next = 2131296560;
+			// aapt resource value: 0x7f090124
+			public const int Next = 2131296548;
 			
 			// aapt resource value: 0x7f09007e
 			public const int Text = 2131296382;
 			
-			// aapt resource value: 0x7f0900dd
-			public const int action0 = 2131296477;
+			// aapt resource value: 0x7f0900d1
+			public const int action0 = 2131296465;
 			
 			// aapt resource value: 0x7f09006a
 			public const int action_bar = 2131296362;
@@ -2423,8 +2420,8 @@ namespace mRides_app
 			// aapt resource value: 0x7f09006b
 			public const int action_context_bar = 2131296363;
 			
-			// aapt resource value: 0x7f0900e1
-			public const int action_divider = 2131296481;
+			// aapt resource value: 0x7f0900d5
+			public const int action_divider = 2131296469;
 			
 			// aapt resource value: 0x7f090003
 			public const int action_menu_divider = 2131296259;
@@ -2471,20 +2468,20 @@ namespace mRides_app
 			// aapt resource value: 0x7f090031
 			public const int bottom = 2131296305;
 			
-			// aapt resource value: 0x7f090103
-			public const int buttonBack = 2131296515;
+			// aapt resource value: 0x7f0900f7
+			public const int buttonBack = 2131296503;
 			
-			// aapt resource value: 0x7f090104
-			public const int buttonDone = 2131296516;
+			// aapt resource value: 0x7f0900f8
+			public const int buttonDone = 2131296504;
 			
 			// aapt resource value: 0x7f090053
 			public const int buttonPanel = 2131296339;
 			
-			// aapt resource value: 0x7f09010f
-			public const int cancelRideCheckBox = 2131296527;
+			// aapt resource value: 0x7f090103
+			public const int cancelRideCheckBox = 2131296515;
 			
-			// aapt resource value: 0x7f0900de
-			public const int cancel_action = 2131296478;
+			// aapt resource value: 0x7f0900d2
+			public const int cancel_action = 2131296466;
 			
 			// aapt resource value: 0x7f090038
 			public const int center = 2131296312;
@@ -2495,11 +2492,11 @@ namespace mRides_app
 			// aapt resource value: 0x7f09003a
 			public const int center_vertical = 2131296314;
 			
-			// aapt resource value: 0x7f090129
-			public const int chatActivityButton = 2131296553;
+			// aapt resource value: 0x7f09011d
+			public const int chatActivityButton = 2131296541;
 			
-			// aapt resource value: 0x7f0900bf
-			public const int chatButton = 2131296447;
+			// aapt resource value: 0x7f0900b2
+			public const int chatButton = 2131296434;
 			
 			// aapt resource value: 0x7f09007b
 			public const int chatMsg = 2131296379;
@@ -2510,8 +2507,8 @@ namespace mRides_app
 			// aapt resource value: 0x7f090061
 			public const int checkbox = 2131296353;
 			
-			// aapt resource value: 0x7f0900e4
-			public const int chronometer = 2131296484;
+			// aapt resource value: 0x7f0900d8
+			public const int chronometer = 2131296472;
 			
 			// aapt resource value: 0x7f090041
 			public const int clip_horizontal = 2131296321;
@@ -2519,8 +2516,8 @@ namespace mRides_app
 			// aapt resource value: 0x7f090042
 			public const int clip_vertical = 2131296322;
 			
-			// aapt resource value: 0x7f0900a8
-			public const int closeFeedback1 = 2131296424;
+			// aapt resource value: 0x7f090098
+			public const int closeFeedback1 = 2131296408;
 			
 			// aapt resource value: 0x7f09002d
 			public const int collapseActionView = 2131296301;
@@ -2531,8 +2528,8 @@ namespace mRides_app
 			// aapt resource value: 0x7f090059
 			public const int contentPanel = 2131296345;
 			
-			// aapt resource value: 0x7f0900b6
-			public const int createRideButton = 2131296438;
+			// aapt resource value: 0x7f0900a9
+			public const int createRideButton = 2131296425;
 			
 			// aapt resource value: 0x7f09005f
 			public const int custom = 2131296351;
@@ -2567,8 +2564,8 @@ namespace mRides_app
 			// aapt resource value: 0x7f09001c
 			public const int disableHome = 2131296284;
 			
-			// aapt resource value: 0x7f09012d
-			public const int driver1 = 2131296557;
+			// aapt resource value: 0x7f090121
+			public const int driver1 = 2131296545;
 			
 			// aapt resource value: 0x7f09006c
 			public const int edit_query = 2131296364;
@@ -2576,8 +2573,8 @@ namespace mRides_app
 			// aapt resource value: 0x7f09002a
 			public const int end = 2131296298;
 			
-			// aapt resource value: 0x7f0900e9
-			public const int end_padder = 2131296489;
+			// aapt resource value: 0x7f0900dd
+			public const int end_padder = 2131296477;
 			
 			// aapt resource value: 0x7f090033
 			public const int enterAlways = 2131296307;
@@ -2594,29 +2591,29 @@ namespace mRides_app
 			// aapt resource value: 0x7f090060
 			public const int expanded_menu = 2131296352;
 			
-			// aapt resource value: 0x7f090120
-			public const int feedbackDateProfileFragment = 2131296544;
+			// aapt resource value: 0x7f090114
+			public const int feedbackDateProfileFragment = 2131296532;
 			
-			// aapt resource value: 0x7f09011f
-			public const int feedbackFragmentLinearLayout1 = 2131296543;
+			// aapt resource value: 0x7f090113
+			public const int feedbackFragmentLinearLayout1 = 2131296531;
 			
-			// aapt resource value: 0x7f090123
-			public const int feedbackFragmentRatingBar = 2131296547;
+			// aapt resource value: 0x7f090117
+			public const int feedbackFragmentRatingBar = 2131296535;
 			
-			// aapt resource value: 0x7f090124
-			public const int feedbackFragmentReview = 2131296548;
+			// aapt resource value: 0x7f090118
+			public const int feedbackFragmentReview = 2131296536;
 			
-			// aapt resource value: 0x7f0900a2
-			public const int feedbackFragmentSize = 2131296418;
+			// aapt resource value: 0x7f090092
+			public const int feedbackFragmentSize = 2131296402;
 			
-			// aapt resource value: 0x7f090122
-			public const int feedbackFragmentUserName = 2131296546;
+			// aapt resource value: 0x7f090116
+			public const int feedbackFragmentUserName = 2131296534;
 			
-			// aapt resource value: 0x7f090121
-			public const int feedbackFragmentUserProfilePicture = 2131296545;
+			// aapt resource value: 0x7f090115
+			public const int feedbackFragmentUserProfilePicture = 2131296533;
 			
-			// aapt resource value: 0x7f0900a3
-			public const int feedbackTitle1 = 2131296419;
+			// aapt resource value: 0x7f090093
+			public const int feedbackTitle1 = 2131296403;
 			
 			// aapt resource value: 0x7f090043
 			public const int fill = 2131296323;
@@ -2630,26 +2627,11 @@ namespace mRides_app
 			// aapt resource value: 0x7f090047
 			public const int @fixed = 2131296327;
 			
-			// aapt resource value: 0x7f090096
-			public const int frameLayout1 = 2131296406;
+			// aapt resource value: 0x7f09010b
+			public const int genderImage = 2131296523;
 			
-			// aapt resource value: 0x7f090093
-			public const int frameLayout2 = 2131296403;
-			
-			// aapt resource value: 0x7f090099
-			public const int frameLayout3 = 2131296409;
-			
-			// aapt resource value: 0x7f09009c
-			public const int frameLayout4 = 2131296412;
-			
-			// aapt resource value: 0x7f09009f
-			public const int frameLayout5 = 2131296415;
-			
-			// aapt resource value: 0x7f090117
-			public const int genderImage = 2131296535;
-			
-			// aapt resource value: 0x7f0900d2
-			public const int goingToTextView1 = 2131296466;
+			// aapt resource value: 0x7f0900c5
+			public const int goingToTextView1 = 2131296453;
 			
 			// aapt resource value: 0x7f090005
 			public const int home = 2131296261;
@@ -2672,11 +2654,11 @@ namespace mRides_app
 			// aapt resource value: 0x7f09004e
 			public const int image = 2131296334;
 			
-			// aapt resource value: 0x7f0900b0
-			public const int imageView2 = 2131296432;
+			// aapt resource value: 0x7f0900a1
+			public const int imageView2 = 2131296417;
 			
-			// aapt resource value: 0x7f0900e8
-			public const int info = 2131296488;
+			// aapt resource value: 0x7f0900dc
+			public const int info = 2131296476;
 			
 			// aapt resource value: 0x7f090000
 			public const int item_touch_helper_previous_elevation = 2131296256;
@@ -2687,20 +2669,20 @@ namespace mRides_app
 			// aapt resource value: 0x7f090019
 			public const int light = 2131296281;
 			
-			// aapt resource value: 0x7f0900e2
-			public const int line1 = 2131296482;
+			// aapt resource value: 0x7f0900d6
+			public const int line1 = 2131296470;
 			
-			// aapt resource value: 0x7f0900e6
-			public const int line3 = 2131296486;
+			// aapt resource value: 0x7f0900da
+			public const int line3 = 2131296474;
 			
-			// aapt resource value: 0x7f0900af
-			public const int linearLayout1 = 2131296431;
+			// aapt resource value: 0x7f09009f
+			public const int linearLayout1 = 2131296415;
 			
-			// aapt resource value: 0x7f090125
-			public const int linearLayout2 = 2131296549;
+			// aapt resource value: 0x7f090119
+			public const int linearLayout2 = 2131296537;
 			
-			// aapt resource value: 0x7f090110
-			public const int linearLayoutBottom = 2131296528;
+			// aapt resource value: 0x7f090104
+			public const int linearLayoutBottom = 2131296516;
 			
 			// aapt resource value: 0x7f09001a
 			public const int listMode = 2131296282;
@@ -2711,65 +2693,65 @@ namespace mRides_app
 			// aapt resource value: 0x7f09007c
 			public const int list_of_messages = 2131296380;
 			
-			// aapt resource value: 0x7f090111
-			public const int list_of_rides = 2131296529;
+			// aapt resource value: 0x7f090105
+			public const int list_of_rides = 2131296517;
 			
-			// aapt resource value: 0x7f0900c6
-			public const int logOutButton = 2131296454;
+			// aapt resource value: 0x7f0900b9
+			public const int logOutButton = 2131296441;
 			
-			// aapt resource value: 0x7f0900dc
-			public const int logTokenButton = 2131296476;
+			// aapt resource value: 0x7f0900d0
+			public const int logTokenButton = 2131296464;
 			
-			// aapt resource value: 0x7f0900b1
-			public const int loginButton = 2131296433;
+			// aapt resource value: 0x7f0900a4
+			public const int loginButton = 2131296420;
 			
-			// aapt resource value: 0x7f0900b2
-			public const int mainMenuLinearLayout = 2131296434;
-			
-			// aapt resource value: 0x7f0900c2
-			public const int mainMenuLinearLayout10 = 2131296450;
-			
-			// aapt resource value: 0x7f0900c5
-			public const int mainMenuLinearLayout11 = 2131296453;
-			
-			// aapt resource value: 0x7f0900b4
-			public const int mainMenuLinearLayout2 = 2131296436;
-			
-			// aapt resource value: 0x7f0900c1
-			public const int mainMenuLinearLayout3 = 2131296449;
+			// aapt resource value: 0x7f0900a5
+			public const int mainMenuLinearLayout = 2131296421;
 			
 			// aapt resource value: 0x7f0900b5
-			public const int mainMenuLinearLayout6 = 2131296437;
+			public const int mainMenuLinearLayout10 = 2131296437;
 			
 			// aapt resource value: 0x7f0900b8
-			public const int mainMenuLinearLayout7 = 2131296440;
+			public const int mainMenuLinearLayout11 = 2131296440;
 			
-			// aapt resource value: 0x7f0900bb
-			public const int mainMenuLinearLayout8 = 2131296443;
+			// aapt resource value: 0x7f0900a7
+			public const int mainMenuLinearLayout2 = 2131296423;
 			
-			// aapt resource value: 0x7f0900be
-			public const int mainMenuLinearLayout9 = 2131296446;
+			// aapt resource value: 0x7f0900b4
+			public const int mainMenuLinearLayout3 = 2131296436;
 			
-			// aapt resource value: 0x7f0900b7
-			public const int mainMenuTextView1 = 2131296439;
+			// aapt resource value: 0x7f0900a8
+			public const int mainMenuLinearLayout6 = 2131296424;
 			
-			// aapt resource value: 0x7f0900ba
-			public const int mainMenuTextView2 = 2131296442;
+			// aapt resource value: 0x7f0900ab
+			public const int mainMenuLinearLayout7 = 2131296427;
 			
-			// aapt resource value: 0x7f0900bd
-			public const int mainMenuTextView3 = 2131296445;
+			// aapt resource value: 0x7f0900ae
+			public const int mainMenuLinearLayout8 = 2131296430;
 			
-			// aapt resource value: 0x7f0900c0
-			public const int mainMenuTextView4 = 2131296448;
+			// aapt resource value: 0x7f0900b1
+			public const int mainMenuLinearLayout9 = 2131296433;
 			
-			// aapt resource value: 0x7f0900c4
-			public const int mainMenuTextView5 = 2131296452;
+			// aapt resource value: 0x7f0900aa
+			public const int mainMenuTextView1 = 2131296426;
 			
-			// aapt resource value: 0x7f0900c7
-			public const int mainMenuTextView6 = 2131296455;
+			// aapt resource value: 0x7f0900ad
+			public const int mainMenuTextView2 = 2131296429;
+			
+			// aapt resource value: 0x7f0900b0
+			public const int mainMenuTextView3 = 2131296432;
 			
 			// aapt resource value: 0x7f0900b3
-			public const int mainMenuWelcomeText = 2131296435;
+			public const int mainMenuTextView4 = 2131296435;
+			
+			// aapt resource value: 0x7f0900b7
+			public const int mainMenuTextView5 = 2131296439;
+			
+			// aapt resource value: 0x7f0900ba
+			public const int mainMenuTextView6 = 2131296442;
+			
+			// aapt resource value: 0x7f0900a6
+			public const int mainMenuWelcomeText = 2131296422;
 			
 			// aapt resource value: 0x7f09008d
 			public const int main_content = 2131296397;
@@ -2777,62 +2759,62 @@ namespace mRides_app
 			// aapt resource value: 0x7f09008e
 			public const int map = 2131296398;
 			
-			// aapt resource value: 0x7f0900cd
-			public const int matchedUserName = 2131296461;
+			// aapt resource value: 0x7f0900c0
+			public const int matchedUserName = 2131296448;
 			
-			// aapt resource value: 0x7f0900cb
-			public const int matchedUserPicture = 2131296459;
+			// aapt resource value: 0x7f0900be
+			public const int matchedUserPicture = 2131296446;
 			
-			// aapt resource value: 0x7f0900ca
-			public const int matchedUserRole = 2131296458;
+			// aapt resource value: 0x7f0900bd
+			public const int matchedUserRole = 2131296445;
 			
-			// aapt resource value: 0x7f0900c9
-			public const int matchedWithTextView1 = 2131296457;
+			// aapt resource value: 0x7f0900bc
+			public const int matchedWithTextView1 = 2131296444;
+			
+			// aapt resource value: 0x7f0900bb
+			public const int matchingLinearLayout1 = 2131296443;
+			
+			// aapt resource value: 0x7f0900bf
+			public const int matchingLinearLayout2 = 2131296447;
+			
+			// aapt resource value: 0x7f0900c3
+			public const int matchingLinearLayout3 = 2131296451;
+			
+			// aapt resource value: 0x7f0900c4
+			public const int matchingLinearLayout4 = 2131296452;
 			
 			// aapt resource value: 0x7f0900c8
-			public const int matchingLinearLayout1 = 2131296456;
+			public const int matchingLinearLayout5 = 2131296456;
 			
-			// aapt resource value: 0x7f0900cc
-			public const int matchingLinearLayout2 = 2131296460;
+			// aapt resource value: 0x7f0900cb
+			public const int matchingLinearLayout6 = 2131296459;
 			
-			// aapt resource value: 0x7f0900d0
-			public const int matchingLinearLayout3 = 2131296464;
+			// aapt resource value: 0x7f0900d4
+			public const int media_actions = 2131296468;
 			
-			// aapt resource value: 0x7f0900d1
-			public const int matchingLinearLayout4 = 2131296465;
+			// aapt resource value: 0x7f090125
+			public const int menu_calendar = 2131296549;
 			
-			// aapt resource value: 0x7f0900d5
-			public const int matchingLinearLayout5 = 2131296469;
+			// aapt resource value: 0x7f090128
+			public const int menu_chat = 2131296552;
 			
-			// aapt resource value: 0x7f090092
-			public const int matchingLinearLayout6 = 2131296402;
+			// aapt resource value: 0x7f090127
+			public const int menu_home = 2131296551;
 			
-			// aapt resource value: 0x7f0900e0
-			public const int media_actions = 2131296480;
+			// aapt resource value: 0x7f090129
+			public const int menu_settings = 2131296553;
 			
-			// aapt resource value: 0x7f090094
-			public const int menu_calendar = 2131296404;
+			// aapt resource value: 0x7f090126
+			public const int menu_user = 2131296550;
 			
-			// aapt resource value: 0x7f09009d
-			public const int menu_chat = 2131296413;
+			// aapt resource value: 0x7f09009b
+			public const int message_text = 2131296411;
 			
 			// aapt resource value: 0x7f09009a
-			public const int menu_map = 2131296410;
+			public const int message_time = 2131296410;
 			
-			// aapt resource value: 0x7f0900a0
-			public const int menu_settings = 2131296416;
-			
-			// aapt resource value: 0x7f090097
-			public const int menu_user = 2131296407;
-			
-			// aapt resource value: 0x7f0900ab
-			public const int message_text = 2131296427;
-			
-			// aapt resource value: 0x7f0900aa
-			public const int message_time = 2131296426;
-			
-			// aapt resource value: 0x7f0900a9
-			public const int message_user = 2131296425;
+			// aapt resource value: 0x7f090099
+			public const int message_user = 2131296409;
 			
 			// aapt resource value: 0x7f09002b
 			public const int middle = 2131296299;
@@ -2843,20 +2825,20 @@ namespace mRides_app
 			// aapt resource value: 0x7f09008f
 			public const int modifyDestinationButton = 2131296399;
 			
-			// aapt resource value: 0x7f0900db
-			public const int msgText1 = 2131296475;
+			// aapt resource value: 0x7f0900cf
+			public const int msgText1 = 2131296463;
 			
 			// aapt resource value: 0x7f090023
 			public const int multiply = 2131296291;
 			
-			// aapt resource value: 0x7f0900c3
-			public const int myProfileButton = 2131296451;
+			// aapt resource value: 0x7f0900b6
+			public const int myProfileButton = 2131296438;
 			
-			// aapt resource value: 0x7f0900bc
-			public const int myRidesButton = 2131296444;
+			// aapt resource value: 0x7f0900af
+			public const int myRidesButton = 2131296431;
 			
-			// aapt resource value: 0x7f09010d
-			public const int nameRiders = 2131296525;
+			// aapt resource value: 0x7f090101
+			public const int nameRiders = 2131296513;
 			
 			// aapt resource value: 0x7f090087
 			public const int navigation_header_container = 2131296391;
@@ -2870,8 +2852,8 @@ namespace mRides_app
 			// aapt resource value: 0x7f09000f
 			public const int normal = 2131296271;
 			
-			// aapt resource value: 0x7f09012e
-			public const int numOfPeople = 2131296558;
+			// aapt resource value: 0x7f090122
+			public const int numOfPeople = 2131296546;
 			
 			// aapt resource value: 0x7f090079
 			public const int openFeedbackAlert = 2131296377;
@@ -2882,44 +2864,44 @@ namespace mRides_app
 			// aapt resource value: 0x7f090055
 			public const int parentPanel = 2131296341;
 			
-			// aapt resource value: 0x7f09012a
-			public const int pickUpButton = 2131296554;
+			// aapt resource value: 0x7f09011e
+			public const int pickUpButton = 2131296542;
 			
-			// aapt resource value: 0x7f09010e
-			public const int pickupLocation = 2131296526;
+			// aapt resource value: 0x7f090102
+			public const int pickupLocation = 2131296514;
 			
 			// aapt resource value: 0x7f090040
 			public const int pin = 2131296320;
 			
-			// aapt resource value: 0x7f0900ec
-			public const int place_autocomplete_clear_button = 2131296492;
+			// aapt resource value: 0x7f0900e0
+			public const int place_autocomplete_clear_button = 2131296480;
 			
 			// aapt resource value: 0x7f090091
 			public const int place_autocomplete_fragment = 2131296401;
 			
-			// aapt resource value: 0x7f0900ee
-			public const int place_autocomplete_powered_by_google = 2131296494;
+			// aapt resource value: 0x7f0900e2
+			public const int place_autocomplete_powered_by_google = 2131296482;
 			
-			// aapt resource value: 0x7f0900f0
-			public const int place_autocomplete_prediction_primary_text = 2131296496;
+			// aapt resource value: 0x7f0900e4
+			public const int place_autocomplete_prediction_primary_text = 2131296484;
 			
-			// aapt resource value: 0x7f0900f1
-			public const int place_autocomplete_prediction_secondary_text = 2131296497;
+			// aapt resource value: 0x7f0900e5
+			public const int place_autocomplete_prediction_secondary_text = 2131296485;
 			
-			// aapt resource value: 0x7f0900ef
-			public const int place_autocomplete_progress = 2131296495;
+			// aapt resource value: 0x7f0900e3
+			public const int place_autocomplete_progress = 2131296483;
 			
-			// aapt resource value: 0x7f0900ea
-			public const int place_autocomplete_search_button = 2131296490;
+			// aapt resource value: 0x7f0900de
+			public const int place_autocomplete_search_button = 2131296478;
 			
-			// aapt resource value: 0x7f0900eb
-			public const int place_autocomplete_search_input = 2131296491;
+			// aapt resource value: 0x7f0900df
+			public const int place_autocomplete_search_input = 2131296479;
 			
-			// aapt resource value: 0x7f0900ed
-			public const int place_autocomplete_separator = 2131296493;
+			// aapt resource value: 0x7f0900e1
+			public const int place_autocomplete_separator = 2131296481;
 			
-			// aapt resource value: 0x7f0900b9
-			public const int preferencesButton = 2131296441;
+			// aapt resource value: 0x7f0900ac
+			public const int preferencesButton = 2131296428;
 			
 			// aapt resource value: 0x7f090006
 			public const int progress_circular = 2131296262;
@@ -2930,53 +2912,53 @@ namespace mRides_app
 			// aapt resource value: 0x7f090063
 			public const int radio = 2131296355;
 			
-			// aapt resource value: 0x7f0900fc
-			public const int radioButtonHandicap = 2131296508;
+			// aapt resource value: 0x7f0900f0
+			public const int radioButtonHandicap = 2131296496;
 			
-			// aapt resource value: 0x7f0900f9
-			public const int radioButtonLuggage = 2131296505;
+			// aapt resource value: 0x7f0900ed
+			public const int radioButtonLuggage = 2131296493;
 			
-			// aapt resource value: 0x7f0900fd
-			public const int radioButtonNoHandicap = 2131296509;
+			// aapt resource value: 0x7f0900f1
+			public const int radioButtonNoHandicap = 2131296497;
 			
-			// aapt resource value: 0x7f0900fa
-			public const int radioButtonNoLuggage = 2131296506;
+			// aapt resource value: 0x7f0900ee
+			public const int radioButtonNoLuggage = 2131296494;
 			
-			// aapt resource value: 0x7f0900ff
-			public const int radioButtonNoPet = 2131296511;
+			// aapt resource value: 0x7f0900f3
+			public const int radioButtonNoPet = 2131296499;
 			
-			// aapt resource value: 0x7f0900f7
-			public const int radioButtonNonSmoker = 2131296503;
+			// aapt resource value: 0x7f0900eb
+			public const int radioButtonNonSmoker = 2131296491;
 			
-			// aapt resource value: 0x7f0900fe
-			public const int radioButtonPet = 2131296510;
+			// aapt resource value: 0x7f0900f2
+			public const int radioButtonPet = 2131296498;
 			
-			// aapt resource value: 0x7f0900f6
-			public const int radioButtonSmoker = 2131296502;
+			// aapt resource value: 0x7f0900ea
+			public const int radioButtonSmoker = 2131296490;
 			
-			// aapt resource value: 0x7f09011d
-			public const int ratingBar = 2131296541;
+			// aapt resource value: 0x7f090111
+			public const int ratingBar = 2131296529;
 			
-			// aapt resource value: 0x7f0900cf
-			public const int ratingBarRiderDestinationMatch = 2131296463;
+			// aapt resource value: 0x7f0900c2
+			public const int ratingBarRiderDestinationMatch = 2131296450;
 			
-			// aapt resource value: 0x7f0900a6
-			public const int reviewEdit1 = 2131296422;
+			// aapt resource value: 0x7f090096
+			public const int reviewEdit1 = 2131296406;
 			
-			// aapt resource value: 0x7f090128
-			public const int reviewFragmentButton = 2131296552;
+			// aapt resource value: 0x7f09011c
+			public const int reviewFragmentButton = 2131296540;
 			
-			// aapt resource value: 0x7f0900a5
-			public const int reviewRatingBar1 = 2131296421;
+			// aapt resource value: 0x7f090095
+			public const int reviewRatingBar1 = 2131296405;
 			
-			// aapt resource value: 0x7f0900a4
-			public const int reviewText1 = 2131296420;
+			// aapt resource value: 0x7f090094
+			public const int reviewText1 = 2131296404;
 			
-			// aapt resource value: 0x7f09012b
-			public const int rider1 = 2131296555;
+			// aapt resource value: 0x7f09011f
+			public const int rider1 = 2131296543;
 			
-			// aapt resource value: 0x7f09012c
-			public const int riderOrDriverSwitch = 2131296556;
+			// aapt resource value: 0x7f090120
+			public const int riderOrDriverSwitch = 2131296544;
 			
 			// aapt resource value: 0x7f09003d
 			public const int right = 2131296317;
@@ -3050,8 +3032,8 @@ namespace mRides_app
 			// aapt resource value: 0x7f090020
 			public const int showTitle = 2131296288;
 			
-			// aapt resource value: 0x7f090113
-			public const int skipButton = 2131296531;
+			// aapt resource value: 0x7f090107
+			public const int skipButton = 2131296519;
 			
 			// aapt resource value: 0x7f090086
 			public const int snackbar_action = 2131296390;
@@ -3065,8 +3047,8 @@ namespace mRides_app
 			// aapt resource value: 0x7f090054
 			public const int spacer = 2131296340;
 			
-			// aapt resource value: 0x7f090102
-			public const int spinnerGender = 2131296514;
+			// aapt resource value: 0x7f0900f6
+			public const int spinnerGender = 2131296502;
 			
 			// aapt resource value: 0x7f090008
 			public const int split_action_bar = 2131296264;
@@ -3086,14 +3068,14 @@ namespace mRides_app
 			// aapt resource value: 0x7f09003e
 			public const int start = 2131296318;
 			
-			// aapt resource value: 0x7f0900df
-			public const int status_bar_latest_event_content = 2131296479;
+			// aapt resource value: 0x7f0900d3
+			public const int status_bar_latest_event_content = 2131296467;
 			
 			// aapt resource value: 0x7f090064
 			public const int submenuarrow = 2131296356;
 			
-			// aapt resource value: 0x7f0900a7
-			public const int submitFeedback1 = 2131296423;
+			// aapt resource value: 0x7f090097
+			public const int submitFeedback1 = 2131296407;
 			
 			// aapt resource value: 0x7f090075
 			public const int submit_area = 2131296373;
@@ -3101,74 +3083,68 @@ namespace mRides_app
 			// aapt resource value: 0x7f09001b
 			public const int tabMode = 2131296283;
 			
-			// aapt resource value: 0x7f09010c
-			public const int tableAbove1 = 2131296524;
+			// aapt resource value: 0x7f090100
+			public const int tableAbove1 = 2131296512;
+			
+			// aapt resource value: 0x7f0900e8
+			public const int tableLayout1 = 2131296488;
 			
 			// aapt resource value: 0x7f0900f4
-			public const int tableLayout1 = 2131296500;
+			public const int tableRowGender = 2131296500;
 			
-			// aapt resource value: 0x7f090100
-			public const int tableRowGender = 2131296512;
+			// aapt resource value: 0x7f0900ef
+			public const int tableRowHandicap = 2131296495;
 			
-			// aapt resource value: 0x7f0900fb
-			public const int tableRowHandicap = 2131296507;
+			// aapt resource value: 0x7f0900ec
+			public const int tableRowLuggage = 2131296492;
 			
-			// aapt resource value: 0x7f0900f8
-			public const int tableRowLuggage = 2131296504;
-			
-			// aapt resource value: 0x7f0900f5
-			public const int tableRowSmoker = 2131296501;
+			// aapt resource value: 0x7f0900e9
+			public const int tableRowSmoker = 2131296489;
 			
 			// aapt resource value: 0x7f090011
 			public const int terrain = 2131296273;
 			
-			// aapt resource value: 0x7f090105
-			public const int testFragment1 = 2131296517;
+			// aapt resource value: 0x7f0900f9
+			public const int testFragment1 = 2131296505;
 			
-			// aapt resource value: 0x7f090106
-			public const int testFragment2 = 2131296518;
+			// aapt resource value: 0x7f0900fa
+			public const int testFragment2 = 2131296506;
 			
-			// aapt resource value: 0x7f090107
-			public const int testFragment3 = 2131296519;
+			// aapt resource value: 0x7f0900fb
+			public const int testFragment3 = 2131296507;
 			
-			// aapt resource value: 0x7f0900e7
-			public const int text = 2131296487;
+			// aapt resource value: 0x7f0900db
+			public const int text = 2131296475;
 			
-			// aapt resource value: 0x7f0900e5
-			public const int text2 = 2131296485;
+			// aapt resource value: 0x7f0900d9
+			public const int text2 = 2131296473;
 			
 			// aapt resource value: 0x7f09005c
 			public const int textSpacerNoButtons = 2131296348;
 			
-			// aapt resource value: 0x7f090098
-			public const int textView1 = 2131296408;
+			// aapt resource value: 0x7f0900a0
+			public const int textView1 = 2131296416;
 			
-			// aapt resource value: 0x7f090095
-			public const int textView2 = 2131296405;
+			// aapt resource value: 0x7f0900a2
+			public const int textView2 = 2131296418;
 			
-			// aapt resource value: 0x7f09009b
-			public const int textView3 = 2131296411;
+			// aapt resource value: 0x7f0900a3
+			public const int textView3 = 2131296419;
 			
-			// aapt resource value: 0x7f09009e
-			public const int textView4 = 2131296414;
+			// aapt resource value: 0x7f0900f5
+			public const int textViewGenderPref = 2131296501;
 			
-			// aapt resource value: 0x7f0900a1
-			public const int textView5 = 2131296417;
+			// aapt resource value: 0x7f0900e6
+			public const int textViewHi = 2131296486;
 			
-			// aapt resource value: 0x7f090101
-			public const int textViewGenderPref = 2131296513;
-			
-			// aapt resource value: 0x7f0900f2
-			public const int textViewHi = 2131296498;
-			
-			// aapt resource value: 0x7f0900f3
-			public const int textViewSetYourPreferences = 2131296499;
+			// aapt resource value: 0x7f0900e7
+			public const int textViewSetYourPreferences = 2131296487;
 			
 			// aapt resource value: 0x7f09008c
 			public const int text_input_password_toggle = 2131296396;
 			
-			// aapt resource value: 0x7f0900e3
-			public const int time = 2131296483;
+			// aapt resource value: 0x7f0900d7
+			public const int time = 2131296471;
 			
 			// aapt resource value: 0x7f090052
 			public const int title = 2131296338;
@@ -3179,11 +3155,11 @@ namespace mRides_app
 			// aapt resource value: 0x7f090080
 			public const int toolbar = 2131296384;
 			
-			// aapt resource value: 0x7f09010b
-			public const int toolbar111 = 2131296523;
+			// aapt resource value: 0x7f0900ff
+			public const int toolbar111 = 2131296511;
 			
-			// aapt resource value: 0x7f09010a
-			public const int toolbar_bot = 2131296522;
+			// aapt resource value: 0x7f0900fe
+			public const int toolbar_bot = 2131296510;
 			
 			// aapt resource value: 0x7f090082
 			public const int toolbar_bottom = 2131296386;
@@ -3191,8 +3167,8 @@ namespace mRides_app
 			// aapt resource value: 0x7f090032
 			public const int top = 2131296306;
 			
-			// aapt resource value: 0x7f090108
-			public const int topBorderedLayout = 2131296520;
+			// aapt resource value: 0x7f0900fc
+			public const int topBorderedLayout = 2131296508;
 			
 			// aapt resource value: 0x7f090056
 			public const int topPanel = 2131296342;
@@ -3206,8 +3182,8 @@ namespace mRides_app
 			// aapt resource value: 0x7f09000b
 			public const int transition_scene_layoutid_cache = 2131296267;
 			
-			// aapt resource value: 0x7f090112
-			public const int trashcanButton = 2131296530;
+			// aapt resource value: 0x7f090106
+			public const int trashcanButton = 2131296518;
 			
 			// aapt resource value: 0x7f090009
 			public const int up = 2131296265;
@@ -3215,68 +3191,68 @@ namespace mRides_app
 			// aapt resource value: 0x7f090021
 			public const int useLogo = 2131296289;
 			
-			// aapt resource value: 0x7f0900d8
-			public const int userMatchButtonAccept = 2131296472;
+			// aapt resource value: 0x7f0900cc
+			public const int userMatchButtonAccept = 2131296460;
 			
-			// aapt resource value: 0x7f0900d9
-			public const int userMatchButtonDecline = 2131296473;
-			
-			// aapt resource value: 0x7f0900da
-			public const int userMatchButtonDone = 2131296474;
-			
-			// aapt resource value: 0x7f0900d3
-			public const int userMatchedDestination = 2131296467;
-			
-			// aapt resource value: 0x7f0900d7
-			public const int userMatchedOrigin = 2131296471;
-			
-			// aapt resource value: 0x7f0900d6
-			public const int userMatchedOriginIndicator = 2131296470;
+			// aapt resource value: 0x7f0900cd
+			public const int userMatchButtonDecline = 2131296461;
 			
 			// aapt resource value: 0x7f0900ce
-			public const int userMatchingChatButton = 2131296462;
+			public const int userMatchButtonDone = 2131296462;
 			
-			// aapt resource value: 0x7f0900d4
-			public const int userMatchingMapPlaceHolder = 2131296468;
+			// aapt resource value: 0x7f0900c6
+			public const int userMatchedDestination = 2131296454;
 			
-			// aapt resource value: 0x7f090118
-			public const int userName = 2131296536;
+			// aapt resource value: 0x7f0900ca
+			public const int userMatchedOrigin = 2131296458;
 			
-			// aapt resource value: 0x7f090119
-			public const int userPhoto = 2131296537;
+			// aapt resource value: 0x7f0900c9
+			public const int userMatchedOriginIndicator = 2131296457;
 			
-			// aapt resource value: 0x7f090126
-			public const int userProfileFragmentName = 2131296550;
+			// aapt resource value: 0x7f0900c1
+			public const int userMatchingChatButton = 2131296449;
 			
-			// aapt resource value: 0x7f09011b
-			public const int userProfileGSD = 2131296539;
+			// aapt resource value: 0x7f0900c7
+			public const int userMatchingMapPlaceHolder = 2131296455;
 			
-			// aapt resource value: 0x7f090114
-			public const int userProfileLinearLayout1 = 2131296532;
+			// aapt resource value: 0x7f09010c
+			public const int userName = 2131296524;
 			
-			// aapt resource value: 0x7f090115
-			public const int userProfileLinearLayout2 = 2131296533;
-			
-			// aapt resource value: 0x7f09011c
-			public const int userProfileLinearLayout4 = 2131296540;
-			
-			// aapt resource value: 0x7f090116
-			public const int userProfileLinearLayout5 = 2131296534;
-			
-			// aapt resource value: 0x7f09011e
-			public const int userProfileListView = 2131296542;
+			// aapt resource value: 0x7f09010d
+			public const int userPhoto = 2131296525;
 			
 			// aapt resource value: 0x7f09011a
-			public const int userProfileinearLayout3 = 2131296538;
+			public const int userProfileFragmentName = 2131296538;
 			
-			// aapt resource value: 0x7f090127
-			public const int viewProfileFragmentButton = 2131296551;
+			// aapt resource value: 0x7f09010f
+			public const int userProfileGSD = 2131296527;
+			
+			// aapt resource value: 0x7f090108
+			public const int userProfileLinearLayout1 = 2131296520;
+			
+			// aapt resource value: 0x7f090109
+			public const int userProfileLinearLayout2 = 2131296521;
+			
+			// aapt resource value: 0x7f090110
+			public const int userProfileLinearLayout4 = 2131296528;
+			
+			// aapt resource value: 0x7f09010a
+			public const int userProfileLinearLayout5 = 2131296522;
+			
+			// aapt resource value: 0x7f090112
+			public const int userProfileListView = 2131296530;
+			
+			// aapt resource value: 0x7f09010e
+			public const int userProfileinearLayout3 = 2131296526;
+			
+			// aapt resource value: 0x7f09011b
+			public const int viewProfileFragmentButton = 2131296539;
 			
 			// aapt resource value: 0x7f09000c
 			public const int view_offset_helper = 2131296268;
 			
-			// aapt resource value: 0x7f090109
-			public const int view_toolbar = 2131296521;
+			// aapt resource value: 0x7f0900fd
+			public const int view_toolbar = 2131296509;
 			
 			// aapt resource value: 0x7f090016
 			public const int wide = 2131296278;
@@ -3470,103 +3446,100 @@ namespace mRides_app
 			public const int Destination = 2130903083;
 			
 			// aapt resource value: 0x7f03002c
-			public const int layout2 = 2130903084;
+			public const int LeaveReview = 2130903084;
 			
 			// aapt resource value: 0x7f03002d
-			public const int LeaveReview = 2130903085;
+			public const int List_Item = 2130903085;
 			
 			// aapt resource value: 0x7f03002e
-			public const int List_Item = 2130903086;
+			public const int List_Ride = 2130903086;
 			
 			// aapt resource value: 0x7f03002f
-			public const int List_Ride = 2130903087;
+			public const int Main = 2130903087;
 			
 			// aapt resource value: 0x7f030030
-			public const int Main = 2130903088;
+			public const int MainMenu = 2130903088;
 			
 			// aapt resource value: 0x7f030031
-			public const int MainMenu = 2130903089;
+			public const int Match = 2130903089;
 			
 			// aapt resource value: 0x7f030032
-			public const int Match = 2130903090;
+			public const int Messaging = 2130903090;
 			
 			// aapt resource value: 0x7f030033
-			public const int Messaging = 2130903091;
+			public const int notification_media_action = 2130903091;
 			
 			// aapt resource value: 0x7f030034
-			public const int notification_media_action = 2130903092;
+			public const int notification_media_cancel_action = 2130903092;
 			
 			// aapt resource value: 0x7f030035
-			public const int notification_media_cancel_action = 2130903093;
+			public const int notification_template_big_media = 2130903093;
 			
 			// aapt resource value: 0x7f030036
-			public const int notification_template_big_media = 2130903094;
+			public const int notification_template_big_media_narrow = 2130903094;
 			
 			// aapt resource value: 0x7f030037
-			public const int notification_template_big_media_narrow = 2130903095;
+			public const int notification_template_lines = 2130903095;
 			
 			// aapt resource value: 0x7f030038
-			public const int notification_template_lines = 2130903096;
+			public const int notification_template_media = 2130903096;
 			
 			// aapt resource value: 0x7f030039
-			public const int notification_template_media = 2130903097;
+			public const int notification_template_part_chronometer = 2130903097;
 			
 			// aapt resource value: 0x7f03003a
-			public const int notification_template_part_chronometer = 2130903098;
+			public const int notification_template_part_time = 2130903098;
 			
 			// aapt resource value: 0x7f03003b
-			public const int notification_template_part_time = 2130903099;
+			public const int place_autocomplete_fragment = 2130903099;
 			
 			// aapt resource value: 0x7f03003c
-			public const int place_autocomplete_fragment = 2130903100;
+			public const int place_autocomplete_item_powered_by_google = 2130903100;
 			
 			// aapt resource value: 0x7f03003d
-			public const int place_autocomplete_item_powered_by_google = 2130903101;
+			public const int place_autocomplete_item_prediction = 2130903101;
 			
 			// aapt resource value: 0x7f03003e
-			public const int place_autocomplete_item_prediction = 2130903102;
+			public const int place_autocomplete_progress = 2130903102;
 			
 			// aapt resource value: 0x7f03003f
-			public const int place_autocomplete_progress = 2130903103;
+			public const int Preferences = 2130903103;
 			
 			// aapt resource value: 0x7f030040
-			public const int Preferences = 2130903104;
+			public const int select_dialog_item_material = 2130903104;
 			
 			// aapt resource value: 0x7f030041
-			public const int select_dialog_item_material = 2130903105;
+			public const int select_dialog_multichoice_material = 2130903105;
 			
 			// aapt resource value: 0x7f030042
-			public const int select_dialog_multichoice_material = 2130903106;
+			public const int select_dialog_singlechoice_material = 2130903106;
 			
 			// aapt resource value: 0x7f030043
-			public const int select_dialog_singlechoice_material = 2130903107;
+			public const int support_simple_spinner_dropdown_item = 2130903107;
 			
 			// aapt resource value: 0x7f030044
-			public const int support_simple_spinner_dropdown_item = 2130903108;
+			public const int TestFragments = 2130903108;
 			
 			// aapt resource value: 0x7f030045
-			public const int TestFragments = 2130903109;
+			public const int toolbar = 2130903109;
 			
 			// aapt resource value: 0x7f030046
-			public const int toolbar = 2130903110;
+			public const int toolbar_bottom = 2130903110;
 			
 			// aapt resource value: 0x7f030047
-			public const int toolbar_bottom = 2130903111;
+			public const int UserCancelRide = 2130903111;
 			
 			// aapt resource value: 0x7f030048
-			public const int UserCancelRide = 2130903112;
+			public const int UserProfile = 2130903112;
 			
 			// aapt resource value: 0x7f030049
-			public const int UserProfile = 2130903113;
+			public const int UserProfileFeedbackFragment = 2130903113;
 			
 			// aapt resource value: 0x7f03004a
-			public const int UserProfileFeedbackFragment = 2130903114;
+			public const int UserProfileFragment = 2130903114;
 			
 			// aapt resource value: 0x7f03004b
-			public const int UserProfileFragment = 2130903115;
-			
-			// aapt resource value: 0x7f03004c
-			public const int UserTypeFragment = 2130903116;
+			public const int UserTypeFragment = 2130903115;
 			
 			static Layout()
 			{
@@ -3893,21 +3866,6 @@ namespace mRides_app
 			
 			// aapt resource value: 0x7f070079
 			public const int matchedWith = 2131165305;
-			
-			// aapt resource value: 0x7f070083
-			public const int menu_chat = 2131165315;
-			
-			// aapt resource value: 0x7f070082
-			public const int menu_general = 2131165314;
-			
-			// aapt resource value: 0x7f070081
-			public const int menu_my_profile = 2131165313;
-			
-			// aapt resource value: 0x7f070080
-			public const int menu_my_rides = 2131165312;
-			
-			// aapt resource value: 0x7f070084
-			public const int menu_settings = 2131165316;
 			
 			// aapt resource value: 0x7f070073
 			public const int message = 2131165299;


### PR DESCRIPTION
#99 A rider should only be able to accept **one** match in a matching session, but the matching kept on continuing when the match is accepted. This change ends the matching session when the rider clicks on accept.

Furthermore, the users, riders and drivers, will be redirected to My Rides page (cancel rides page) when the matching activity is done.