### PR TITLE
#108 Corrected the parameters sent to the console mapper from the mat…

### DIFF
--- a/mRides-app/Activities/MatchActivity.cs
+++ b/mRides-app/Activities/MatchActivity.cs
@@ -247,7 +247,7 @@ namespace mRides_app
                 }
                 else
                 {
-                    consoleMapper.Confirm(this.matchedRequests[currentMatchedUserIndex].ID, this.userRequest.ID);
+                    consoleMapper.Confirm(this.userRequest.ID, this.matchedRequests[currentMatchedUserIndex].ID);
                     this.Done();
                 }
             }


### PR DESCRIPTION
#108 
Corrected the parameters sent to the console mapper from the match activity

The match activity sent the param in reverse order when accepting a
match as a rider, it is now fixed.