### PR TITLE
#112 Updated MatchActivity to send the user back to the main menu if …

### DIFF
--- a/mRides-app/Activities/MatchActivity.cs
+++ b/mRides-app/Activities/MatchActivity.cs
@@ -486,6 +486,12 @@ namespace mRides_app
             {
                 // Display some message to the user
                 Toast.MakeText(ApplicationContext, Resources.GetString(Resource.String.matchNoMatchFound), ToastLength.Long).Show();
+
+                // Go back to the main menu, clearing the activity stack
+                Intent intent = new Intent(this, typeof(MainMenuActivity));
+                intent.AddFlags(ActivityFlags.NewTask);
+                intent.AddFlags(ActivityFlags.ClearTask);
+                this.StartActivity(intent);
                 Finish();
             }
         }


### PR DESCRIPTION
#112 Updated MatchActivity to send the user back to the main menu if no match is found, instead of simply ending the activity

- MatchActivity:
If no match is found, the user is now sent back to the main menu,
removing all activities from the back stack, instead of simply ending
the activity which took the user back to the map.